### PR TITLE
use custom runtime image /3

### DIFF
--- a/lotus-testground/docker-images/Dockerfile.oni-runtime
+++ b/lotus-testground/docker-images/Dockerfile.oni-runtime
@@ -1,0 +1,11 @@
+ARG GO_VERSION=1.14.2
+
+ARG RUNTIME_IMAGE=busybox:1.31.1-glibc
+
+FROM golang:${GO_VERSION}-buster AS builder
+
+RUN apt-get update && apt-get install -y ca-certificates llvm clang mesa-opencl-icd ocl-icd-opencl-dev jq gcc git bzr pkg-config
+
+FROM ${RUNTIME_IMAGE} AS binary
+
+COPY --from=builder /usr/lib/x86_64-linux-gnu/* /lib/x86_64-linux-gnu/* /usr/lib/

--- a/lotus-testground/manifest.toml
+++ b/lotus-testground/manifest.toml
@@ -6,6 +6,7 @@ runner = "local:exec"
 
 [builders."docker:go"]
 enabled = true
+runtime_image = "iptestground/oni-runtime:latest"
 skip_runtime_image = false
 
 [builders."docker:go".dockerfile_extensions]
@@ -20,7 +21,6 @@ RUN cd ${PLAN_DIR}/../lotus/extern/filecoin-ffi \
 """
 
 post_runtime_copy = """
-COPY --from=builder /usr/lib/x86_64-linux-gnu/* /lib/x86_64-linux-gnu/* /usr/lib/
 COPY --from=builder /lotus/build/bootstrap/* /lotus/build/bootstrap/
 COPY --from=builder /lotus/build/proof-params/* /lotus/build/proof-params/
 """


### PR DESCRIPTION
Shaving off +30sec. from the build time.

---

I've included a Dockerfile for `iptestground/oni-runtime:latest`. I don't think we need any automation on it right now, if necessary we can rebuild and push.