### PR TITLE
make the testkit friends with local:exec.

### DIFF
--- a/DELVING.md
+++ b/DELVING.md
@@ -14,7 +14,7 @@ All our compositions should carry this fragment:
 
 ```toml
 [global.run_config]
-  exposed_ports = ["6060", "1234", "2345"]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 ```
 
 This tells Testground to expose the following ports:

--- a/lotus-soup/compositions/composition-k8s-10-3.toml
+++ b/lotus-soup/compositions/composition-k8s-10-3.toml
@@ -16,7 +16,7 @@
   registry_type="aws"
 
 [global.run_config]
-  exposed_ports = ["6060", "1234", "2345"]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
 [global.run.test_params]
   clients = "10"

--- a/lotus-soup/compositions/composition-k8s-3-1.toml
+++ b/lotus-soup/compositions/composition-k8s-3-1.toml
@@ -16,7 +16,7 @@
   registry_type="aws"
 
 [global.run_config]
-  exposed_ports = ["6060", "1234", "2345"]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
 [global.run.test_params]
   clients = "3"

--- a/lotus-soup/compositions/composition-k8s-3-2.toml
+++ b/lotus-soup/compositions/composition-k8s-3-2.toml
@@ -16,7 +16,7 @@
   registry_type="aws"
 
 [global.run_config]
-  exposed_ports = ["6060", "1234", "2345"]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
 [global.run.test_params]
   clients = "3"

--- a/lotus-soup/compositions/composition-k8s.toml
+++ b/lotus-soup/compositions/composition-k8s.toml
@@ -16,7 +16,7 @@
   registry_type="aws"
 
 [global.run_config]
-  exposed_ports = ["6060", "1234", "2345"]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
 [global.run.test_params]
   clients = "1"

--- a/lotus-soup/compositions/composition.toml
+++ b/lotus-soup/compositions/composition.toml
@@ -13,7 +13,7 @@
   enable_go_build_cache = true
 
 [global.run_config]
-  exposed_ports = ["6060", "1234", "2345"]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
 [global.build]
   selectors = ["testground"]

--- a/lotus-soup/go.mod
+++ b/lotus-soup/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub-tracer v0.0.0-20200626141350-e730b32bf1e6
 	github.com/multiformats/go-multiaddr v0.2.2
 	github.com/multiformats/go-multiaddr-net v0.1.5
-	github.com/testground/sdk-go v0.2.3-0.20200630140907-cda3c5ac055b
+	github.com/testground/sdk-go v0.2.3-0.20200706132230-6a65ddac2d8c
 	go.opencensus.io v0.22.4
 )
 

--- a/lotus-soup/go.sum
+++ b/lotus-soup/go.sum
@@ -303,8 +303,8 @@ github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
-github.com/go-redis/redis/v7 v7.2.0 h1:CrCexy/jYWZjW0AyVoHlcJUeZN19VWlbepTh1Vq6dJs=
-github.com/go-redis/redis/v7 v7.2.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
+github.com/go-redis/redis/v7 v7.4.0 h1:7obg6wUoj05T0EpY0o8B59S9w5yeMWql7sw2kwNW1x4=
+github.com/go-redis/redis/v7 v7.4.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
@@ -364,6 +364,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -460,6 +462,8 @@ github.com/influxdata/influxdb v1.8.0 h1:/X+G+i3udzHVxpBMuXdPZcUbkIE0ouT+6U+CzQT
 github.com/influxdata/influxdb v1.8.0/go.mod h1:SIzcnsjaHRFpmlxpJ4S3NT64qtEKYweNTUMb/vh0OMQ=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d h1:/WZQPMZNsjZ7IlCpsLGdQBINg5bxKQ1K1sh6awxLtkA=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/influxdata/influxdb1-client v0.0.0-20200515024757-02f0bf5dbca3 h1:k3/6a1Shi7GGCp9QpyYuXsMM6ncTOjCzOE9Fd6CDA+Q=
+github.com/influxdata/influxdb1-client v0.0.0-20200515024757-02f0bf5dbca3/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/influxql v1.1.0/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e/go.mod h1:4kt73NQhadE3daL3WhR5EJ/J2ocX0PZzwxQ0gXJ7oFE=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
@@ -676,6 +680,7 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jsternberg/zap-logfmt v1.0.0/go.mod h1:uvPs/4X51zdkcm5jXl5SYoN+4RK21K8mysFmDaM/h+o=
@@ -1208,9 +1213,10 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.4.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
-github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
+github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
+github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -1239,6 +1245,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.1.0 h1:jhMy6QXfi3y2HEzFoyuCj40z4OZIIHHPtFyCMftmvKA=
 github.com/prometheus/procfs v0.1.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
+github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -1341,8 +1349,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/testground/sdk-go v0.2.3-0.20200630140907-cda3c5ac055b h1:W8EDNshcIaO7LaGVFc7DI9VlAnhGzRDVmGx+h9Mer8g=
-github.com/testground/sdk-go v0.2.3-0.20200630140907-cda3c5ac055b/go.mod h1:3auzMDXaoK7NQ+CLQS3pqp4hmREECWO9V+TJi/IWmms=
+github.com/testground/sdk-go v0.2.3-0.20200706132230-6a65ddac2d8c h1:TY0ghu3uY2SckyRvwSzzS0Am08KIX3ISeirp0riZLSw=
+github.com/testground/sdk-go v0.2.3-0.20200706132230-6a65ddac2d8c/go.mod h1:3ewI3dydDseP7eCO1MHGh+67simvbkcUnguPYssFqiA=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -1660,6 +1668,9 @@ golang.org/x/sys v0.0.0-20200509044756-6aff5f38e54f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 h1:OjiUf46hAmXblsZdnoSXsEUSKU8r1UEzcL5RVZ4gO9Y=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1810,6 +1821,8 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
+google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/lotus-soup/main.go
+++ b/lotus-soup/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 var cases = map[string]interface{}{
-	"deals-e2e": testkit.WrapTestEnvironment(dealsE2E),
+	"deals-e2e":     testkit.WrapTestEnvironment(dealsE2E),
 	"drand-halting": testkit.WrapTestEnvironment(dealsE2E),
 }
 

--- a/lotus-soup/manifest.toml
+++ b/lotus-soup/manifest.toml
@@ -5,10 +5,16 @@ extra_sources = { "exec:go" = ["../extra/filecoin-ffi"] }
 builder = "docker:go"
 runner = "local:docker"
 
+[builders."exec:go"]
+enabled = true
+
 [builders."docker:go"]
 enabled = true
 build_base_image = "iptestground/oni-buildbase:v3"
 runtime_image = "iptestground/oni-runtime:v2"
+
+[runners."local:exec"]
+enabled = true
 
 [runners."local:docker"]
 enabled = true

--- a/lotus-soup/testkit/lotus_opts.go
+++ b/lotus-soup/testkit/lotus_opts.go
@@ -47,12 +47,12 @@ func withPubsubConfig(bootstrapper bool, pubsubTracer string) node.Option {
 }
 
 func withListenAddress(ip string) node.Option {
-	addrs := []string{fmt.Sprintf("/ip4/%s/tcp/4001", ip)}
+	addrs := []string{fmt.Sprintf("/ip4/%s/tcp/0", ip)}
 	return node.Override(node.StartListeningKey, lp2p.StartListening(addrs))
 }
 
 func withMinerListenAddress(ip string) node.Option {
-	addrs := []string{fmt.Sprintf("/ip4/%s/tcp/4002", ip)}
+	addrs := []string{fmt.Sprintf("/ip4/%s/tcp/0", ip)}
 	return node.Override(node.StartListeningKey, lp2p.StartListening(addrs))
 }
 

--- a/lotus-soup/testkit/node.go
+++ b/lotus-soup/testkit/node.go
@@ -16,7 +16,6 @@ import (
 	"github.com/filecoin-project/lotus/node"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	modtest "github.com/filecoin-project/lotus/node/modules/testing"
-	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	saminer "github.com/filecoin-project/specs-actors/actors/builtin/miner"
@@ -24,6 +23,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
 	logging "github.com/ipfs/go-log/v2"
 	influxdb "github.com/kpacha/opencensus-influxdb"
+	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	manet "github.com/multiformats/go-multiaddr-net"
@@ -205,22 +205,17 @@ func GetRandomBeaconOpts(ctx context.Context, t *TestEnvironment) (node.Option, 
 	}
 }
 
-func startServer(repo *repo.MemRepo, srv *http.Server) error {
-	endpoint, err := repo.APIEndpoint()
-	if err != nil {
-		return err
-	}
-
+func startServer(endpoint ma.Multiaddr, srv *http.Server) (listenAddr string, err error) {
 	lst, err := manet.Listen(endpoint)
 	if err != nil {
-		return fmt.Errorf("could not listen: %w", err)
+		return "", fmt.Errorf("could not listen: %w", err)
 	}
 
 	go func() {
 		_ = srv.Serve(manet.NetListener(lst))
 	}()
 
-	return nil
+	return lst.Addr().String(), nil
 }
 
 func registerAndExportMetrics(instanceName string) {

--- a/lotus-soup/testkit/role_bootstrapper.go
+++ b/lotus-soup/testkit/role_bootstrapper.go
@@ -3,6 +3,7 @@ package testkit
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/filecoin-project/lotus/build"
@@ -105,7 +106,7 @@ func PrepareBootstrapper(t *TestEnvironment) (*Bootstrapper, error) {
 		node.Online(),
 		node.Repo(repo.NewMemory(nil)),
 		node.Override(new(modules.Genesis), modtest.MakeGenesisMem(&genesisBuffer, genesisTemplate)),
-		withApiEndpoint("/ip4/0.0.0.0/tcp/1234"),
+		withApiEndpoint(fmt.Sprintf("/ip4/0.0.0.0/tcp/%s", t.PortNumber("node_rpc", "0"))),
 		withListenAddress(bootstrapperIP),
 		withBootstrapper(nil),
 		withPubsubConfig(true, pubsubTracerMaddr),

--- a/lotus-soup/testkit/role_client.go
+++ b/lotus-soup/testkit/role_client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/wallet"
 	"github.com/filecoin-project/lotus/node"
 	"github.com/filecoin-project/lotus/node/repo"
-
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 )
 
@@ -64,7 +63,7 @@ func PrepareClient(t *TestEnvironment) (*LotusClient, error) {
 		node.FullAPI(&n.FullApi),
 		node.Online(),
 		node.Repo(nodeRepo),
-		withApiEndpoint("/ip4/0.0.0.0/tcp/1234"),
+		withApiEndpoint(fmt.Sprintf("/ip4/0.0.0.0/tcp/%s", t.PortNumber("node_rpc", "0"))),
 		withGenesis(genesisMsg.Genesis),
 		withListenAddress(clientIP),
 		withBootstrapper(genesisMsg.Bootstrapper),
@@ -83,7 +82,7 @@ func PrepareClient(t *TestEnvironment) (*LotusClient, error) {
 		return nil, err
 	}
 
-	err = startClientAPIServer(nodeRepo, n.FullApi)
+	err = startFullNodeAPIServer(t, nodeRepo, n.FullApi)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +121,7 @@ func (c *LotusClient) RunDefault() error {
 	return nil
 }
 
-func startClientAPIServer(repo *repo.MemRepo, api api.FullNode) error {
+func startFullNodeAPIServer(t *TestEnvironment, repo *repo.MemRepo, api api.FullNode) error {
 	rpcServer := jsonrpc.NewServer()
 	rpcServer.Register("Filecoin", apistruct.PermissionedFullAPI(api))
 
@@ -135,5 +134,16 @@ func startClientAPIServer(repo *repo.MemRepo, api api.FullNode) error {
 
 	srv := &http.Server{Handler: http.DefaultServeMux}
 
-	return startServer(repo, srv)
+	endpoint, err := repo.APIEndpoint()
+	if err != nil {
+		return fmt.Errorf("no API endpoint in repo: %w", err)
+	}
+
+	listenAddr, err := startServer(endpoint, srv)
+	if err != nil {
+		return fmt.Errorf("failed to start client API endpoint: %w", err)
+	}
+
+	t.RecordMessage("started node API server at %s", listenAddr)
+	return nil
 }

--- a/lotus-soup/testkit/testenv.go
+++ b/lotus-soup/testkit/testenv.go
@@ -32,7 +32,7 @@ func (t *TestEnvironment) DurationParam(name string) time.Duration {
 	return d
 }
 
-func (t *TestEnvironment) DebugSpew(format string, args... interface{}) {
+func (t *TestEnvironment) DebugSpew(format string, args ...interface{}) {
 	t.RecordMessage(spew.Sprintf(format, args...))
 }
 


### PR DESCRIPTION
This PR makes it possible for us to use the `exec:go` builder with the `local:exec` runner, thus unlocking must faster development iterations and feedback cycles.

This builds on https://github.com/testground/testground/pull/1095, so make sure to pull from testground oni branch, and do a `go install`. No rebuilding of sidecar containers necessary!

The full node and miner API server port numbers are now picked up from environment variables, falling back to 0 (random) if not set, as it happens in `local:exec`, as this runner does not support port mappings for obvious reasons.

The testkit prints the port numbers so you can configure your lotus CLI accordingly.

- When running with `local:docker`, you will see the following, and you will need to resort to `docker ps` to figure out the host port mapping.

```
Jul  6 13:27:48.594698	INFO	4.4121s    MESSAGE << 9a7a66b5a9ea >> started storage miner API server at 0.0.0.0:2345	{"req_id": "5ba066e1"}
```

- When running with `local:exec`, you will see the actual port number:

```
Jul  6 13:15:18.481647	INFO	3.2886s    MESSAGE << instance   3 >> started node API server at 0.0.0.0:57409	{"req_id": "0e9ae6ce"}
```