### PR TITLE
Attofil

### DIFF
--- a/lotus-soup/compositions/composition.toml
+++ b/lotus-soup/compositions/composition.toml
@@ -22,7 +22,7 @@
   clients = "3"
   miners = "2"
   genesis_timestamp_offset = "0"
-  balance = "2000000000"    ## be careful, this is in FIL.
+  balance = "20000000.5"
   sectors = "10"
   random_beacon_type = "mock"
   mining_mode = "natural"

--- a/lotus-soup/manifest.toml
+++ b/lotus-soup/manifest.toml
@@ -35,7 +35,7 @@ instances = { min = 1, max = 100, default = 5 }
   [testcases.params]
   clients   = { type = "int", default = 1 }
   miners    = { type = "int", default = 1 }
-  balance   = { type = "int", default = 1 }
+  balance   = { type = "float", default = 1 }
   sectors   = { type = "int", default = 1 }
   role      = { type = "string" }
 
@@ -64,7 +64,7 @@ instances = { min = 1, max = 100, default = 5 }
   [testcases.params]
   clients = { type = "int", default = 1 }
   miners = { type = "int", default = 1 }
-  balance = { type = "int", default = 1 }
+  balance = { type = "float", default = 1 }
   sectors = { type = "int", default = 1 }
   role = { type = "string" }
   genesis_timestamp_offset = { type = "int", default = 0 }
@@ -94,7 +94,7 @@ instances = { min = 1, max = 100, default = 5 }
   [testcases.params]
   clients = { type = "int", default = 1 }
   miners = { type = "int", default = 1 }
-  balance = { type = "int", default = 1 }
+  balance = { type = "float", default = 1 }
   sectors = { type = "int", default = 1 }
   role = { type = "string" }
 
@@ -127,7 +127,7 @@ instances = { min = 1, max = 100, default = 5 }
   [testcases.params]
   clients = { type = "int", default = 1 }
   miners = { type = "int", default = 1 }
-  balance = { type = "int", default = 1 }
+  balance = { type = "float", default = 1 }
   sectors = { type = "int", default = 1 }
   role = { type = "string" }
   genesis_timestamp_offset = { type = "int", default = 0 }

--- a/lotus-soup/testkit/role_bootstrapper.go
+++ b/lotus-soup/testkit/role_bootstrapper.go
@@ -58,7 +58,7 @@ func PrepareBootstrapper(t *TestEnvironment) (*Bootstrapper, error) {
 
 	totalBalance := big.Zero()
 	for _, b := range balances {
-		totalBalance = big.Add(attoFil(b.Balance), totalBalance)
+		totalBalance = big.Add(filToAttoFil(b.Balance), totalBalance)
 	}
 
 	totalBalanceFil := attoFilToFil(totalBalance)
@@ -78,7 +78,7 @@ func PrepareBootstrapper(t *TestEnvironment) (*Bootstrapper, error) {
 	var genesisMiners []genesis.Miner
 
 	for _, bm := range balances {
-		balance := attoFil(bm.Balance)
+		balance := filToAttoFil(bm.Balance)
 		t.RecordMessage("balance assigned to actor %s: %s AttoFIL", bm.Addr, balance)
 		genesisActors = append(genesisActors,
 			genesis.Actor{
@@ -181,8 +181,8 @@ func (b *Bootstrapper) RunDefault() error {
 	return nil
 }
 
-// attoFil converts a fractional filecoin value into AttoFIL, rounding if necessary
-func attoFil(f float64) big.Int {
+// filToAttoFil converts a fractional filecoin value into AttoFIL, rounding if necessary
+func filToAttoFil(f float64) big.Int {
 	a := mbig.NewFloat(f)
 	a.Mul(a, mbig.NewFloat(float64(build.FilecoinPrecision)))
 	i, _ := a.Int(nil)

--- a/lotus-soup/testkit/role_bootstrapper.go
+++ b/lotus-soup/testkit/role_bootstrapper.go
@@ -61,8 +61,9 @@ func PrepareBootstrapper(t *TestEnvironment) (*Bootstrapper, error) {
 		totalBalance = big.Add(attoFil(b.Balance), totalBalance)
 	}
 
-	t.RecordMessage("TOTAL BALANCE: %s AttoFIL (%f FIL)", totalBalance, fractionalFil(totalBalance))
-	if max := types.TotalFilecoinInt; totalBalance.GreaterThanEqual(max) {
+	totalBalanceFil := attoFilToFil(totalBalance)
+	t.RecordMessage("TOTAL BALANCE: %s AttoFIL (%s FIL)", totalBalance, totalBalanceFil)
+	if max := types.TotalFilecoinInt; totalBalanceFil.GreaterThanEqual(max) {
 		panic(fmt.Sprintf("total sum of balances is greater than max Filecoin ever; sum=%s, max=%s", totalBalance, max))
 	}
 
@@ -188,12 +189,9 @@ func attoFil(f float64) big.Int {
 	return big.Int{Int: i}
 }
 
-// fractionalFil converts from AttoFIL to a fractional Fil value
-// possibly losing some precision due to floating point gremlins
-func fractionalFil(atto big.Int) float64 {
-	f := mbig.NewFloat(0)
-	f.SetInt(atto.Int)
-	f.Quo(f, mbig.NewFloat(float64(build.FilecoinPrecision)))
-	val, _ := f.Float64()
-	return val
+func attoFilToFil(atto big.Int) big.Int {
+	i := big.NewInt(0)
+	i.Add(i.Int, atto.Int)
+	i.Div(i.Int, big.NewIntUnsigned(build.FilecoinPrecision).Int)
+	return i
 }

--- a/lotus-soup/testkit/role_client.go
+++ b/lotus-soup/testkit/role_client.go
@@ -45,7 +45,7 @@ func PrepareClient(t *TestEnvironment) (*LotusClient, error) {
 	}
 
 	// publish the account ID/balance
-	balance := t.IntParam("balance")
+	balance := t.FloatParam("balance")
 	balanceMsg := &InitialBalanceMsg{Addr: walletKey.Address, Balance: balance}
 	t.SyncClient.Publish(ctx, BalanceTopic, balanceMsg)
 

--- a/lotus-soup/testkit/role_miner.go
+++ b/lotus-soup/testkit/role_miner.go
@@ -63,7 +63,7 @@ func PrepareMiner(t *TestEnvironment) (*LotusMiner, error) {
 	}
 
 	// publish the account ID/balance
-	balance := t.IntParam("balance")
+	balance := t.FloatParam("balance")
 	balanceMsg := &InitialBalanceMsg{Addr: walletKey.Address, Balance: balance}
 	t.SyncClient.Publish(ctx, BalanceTopic, balanceMsg)
 

--- a/lotus-soup/testkit/sync.go
+++ b/lotus-soup/testkit/sync.go
@@ -27,7 +27,7 @@ var (
 
 type InitialBalanceMsg struct {
 	Addr    address.Address
-	Balance int
+	Balance float64
 }
 
 type PresealMsg struct {


### PR DESCRIPTION
This changes the `balance` param to a float and lets you specify fractions of a filecoin, so you can have a balance of less than a Fil. 

I did this instead of accepting AttoFIL directly because we're parsing the parameter before sharing on the sync service, and if you try to parse AttoFIL into a `uint64` it fails with "value out of range" after you hit about 18 FIL.  Also it's awkward to work with such huge numbers, and this way we don't need to change any existing compositions, since the units are the same.

Closes #108 