### PR TITLE
consistent compositions

### DIFF
--- a/lotus-soup/compositions/composition-drand-halt.toml
+++ b/lotus-soup/compositions/composition-drand-halt.toml
@@ -12,11 +12,11 @@
 [global.build]
   selectors = ["testground"]
 
-[global.build_config]
-  enable_go_build_cache = true
-
 [global.run_config]
   exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  enable_go_build_cache = true
 
 [global.run.test_params]
   clients = "1"

--- a/lotus-soup/compositions/composition-k8s-10-3.toml
+++ b/lotus-soup/compositions/composition-k8s-10-3.toml
@@ -9,14 +9,17 @@
   builder = "docker:go"
   runner = "cluster:k8s"
 
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
 [global.build_config]
   push_registry=true
   go_proxy_mode="remote"
   go_proxy_url="http://localhost:8081"
   registry_type="aws"
-
-[global.run_config]
-  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
 [global.run.test_params]
   clients = "10"

--- a/lotus-soup/compositions/composition-k8s-3-1.toml
+++ b/lotus-soup/compositions/composition-k8s-3-1.toml
@@ -9,14 +9,17 @@
   builder = "docker:go"
   runner = "cluster:k8s"
 
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
 [global.build_config]
   push_registry=true
   go_proxy_mode="remote"
   go_proxy_url="http://localhost:8081"
   registry_type="aws"
-
-[global.run_config]
-  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
 [global.run.test_params]
   clients = "3"

--- a/lotus-soup/compositions/composition-k8s-3-2.toml
+++ b/lotus-soup/compositions/composition-k8s-3-2.toml
@@ -9,14 +9,17 @@
   builder = "docker:go"
   runner = "cluster:k8s"
 
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
 [global.build_config]
   push_registry=true
   go_proxy_mode="remote"
   go_proxy_url="http://localhost:8081"
   registry_type="aws"
-
-[global.run_config]
-  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
 [global.run.test_params]
   clients = "3"

--- a/lotus-soup/compositions/composition-k8s.toml
+++ b/lotus-soup/compositions/composition-k8s.toml
@@ -9,14 +9,17 @@
   builder = "docker:go"
   runner = "cluster:k8s"
 
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
 [global.build_config]
   push_registry=true
   go_proxy_mode="remote"
   go_proxy_url="http://localhost:8081"
   registry_type="aws"
-
-[global.run_config]
-  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
 [global.run.test_params]
   clients = "1"

--- a/lotus-soup/compositions/composition-local-drand.toml
+++ b/lotus-soup/compositions/composition-local-drand.toml
@@ -9,6 +9,12 @@
   builder = "docker:go"
   runner = "local:docker"
 
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
 [global.build_config]
   enable_go_build_cache = true
 
@@ -31,7 +37,6 @@
   [groups.run]
     [groups.run.test_params]
       role = "bootstrapper"
-
 
 [[groups]]
   id = "miners"

--- a/lotus-soup/compositions/composition-natural.toml
+++ b/lotus-soup/compositions/composition-natural.toml
@@ -9,6 +9,12 @@
   builder = "docker:go"
   runner = "local:docker"
 
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
 [global.build_config]
   enable_go_build_cache = true
 

--- a/lotus-soup/compositions/composition-paych-stress.toml
+++ b/lotus-soup/compositions/composition-paych-stress.toml
@@ -9,14 +9,14 @@
   builder = "exec:go"
   runner = "local:exec"
 
-[global.build_config]
-  enable_go_build_cache = true
+[global.build]
+  selectors = ["testground"]
 
 [global.run_config]
   exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
-[global.build]
-  selectors = ["testground"]
+[global.build_config]
+  enable_go_build_cache = true
 
 [global.run.test_params]
   clients = "2"

--- a/lotus-soup/compositions/composition-stress-test-concurrent-natural.toml
+++ b/lotus-soup/compositions/composition-stress-test-concurrent-natural.toml
@@ -9,14 +9,14 @@
   builder = "docker:go"
   runner = "local:docker"
 
-[global.build_config]
-  enable_go_build_cache = true
-
 [global.build]
   selectors = ["testground"]
 
 [global.run_config]
-  exposed_ports = ["6060", "1234", "2345"]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  enable_go_build_cache = true
 
 [global.run.test_params]
   clients = "3"

--- a/lotus-soup/compositions/composition-stress-test-concurrent.toml
+++ b/lotus-soup/compositions/composition-stress-test-concurrent.toml
@@ -9,14 +9,14 @@
   builder = "docker:go"
   runner = "local:docker"
 
-[global.build_config]
-  enable_go_build_cache = true
-
 [global.build]
   selectors = ["testground"]
 
 [global.run_config]
-  exposed_ports = ["6060", "1234", "2345"]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  enable_go_build_cache = true
 
 [global.run.test_params]
   clients = "3"

--- a/lotus-soup/compositions/composition-stress-test-serial-natural.toml
+++ b/lotus-soup/compositions/composition-stress-test-serial-natural.toml
@@ -9,14 +9,14 @@
   builder = "docker:go"
   runner = "local:docker"
 
-[global.build_config]
-  enable_go_build_cache = true
-
 [global.build]
   selectors = ["testground"]
 
 [global.run_config]
-  exposed_ports = ["6060", "1234", "2345"]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  enable_go_build_cache = true
 
 [global.run.test_params]
   clients = "3"

--- a/lotus-soup/compositions/composition-stress-test-serial.toml
+++ b/lotus-soup/compositions/composition-stress-test-serial.toml
@@ -9,14 +9,14 @@
   builder = "docker:go"
   runner = "local:docker"
 
-[global.build_config]
-  enable_go_build_cache = true
-
 [global.build]
   selectors = ["testground"]
 
 [global.run_config]
-  exposed_ports = ["6060", "1234", "2345"]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  enable_go_build_cache = true
 
 [global.run.test_params]
   clients = "3"

--- a/lotus-soup/compositions/composition-tracer.toml
+++ b/lotus-soup/compositions/composition-tracer.toml
@@ -9,6 +9,12 @@
   builder = "docker:go"
   runner = "local:docker"
 
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
 [global.build_config]
   enable_go_build_cache = true
 

--- a/lotus-soup/compositions/composition.toml
+++ b/lotus-soup/compositions/composition.toml
@@ -9,14 +9,14 @@
   builder = "exec:go"
   runner = "local:exec"
 
-[global.build_config]
-  enable_go_build_cache = true
+[global.build]
+  selectors = ["testground"]
 
 [global.run_config]
   exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
-[global.build]
-  selectors = ["testground"]
+[global.build_config]
+  enable_go_build_cache = true
 
 [global.run.test_params]
   clients = "3"

--- a/lotus-soup/compositions/stress-test-concurrent-natural-k8s.toml
+++ b/lotus-soup/compositions/stress-test-concurrent-natural-k8s.toml
@@ -9,17 +9,17 @@
   builder = "docker:go"
   runner = "cluster:k8s"
 
-[global.build_config]
-  push_registry=true
-  go_proxy_mode="remote"
-  go_proxy_url="http://localhost:8081"
-  registry_type="aws"
-
 [global.build]
   selectors = ["testground"]
 
 [global.run_config]
   exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  push_registry=true
+  go_proxy_mode="remote"
+  go_proxy_url="http://localhost:8081"
+  registry_type="aws"
 
 [global.run.test_params]
   clients = "6"


### PR DESCRIPTION
1. Make sure all our compositions use the build tag `testground`, otherwise they won't compile.
2. Make sure all our compositions use the proper exposed_ports format.