### PR TITLE
bump up balances

### DIFF
--- a/lotus-soup/compositions/composition-drand-halt.toml
+++ b/lotus-soup/compositions/composition-drand-halt.toml
@@ -21,7 +21,7 @@
 [global.run.test_params]
   clients = "1"
   miners = "1"
-  balance = "2000"
+  balance = "20000000"
   sectors = "10"
   random_beacon_type = "local-drand"
   genesis_timestamp_offset = "0"

--- a/lotus-soup/compositions/composition-k8s-10-3.toml
+++ b/lotus-soup/compositions/composition-k8s-10-3.toml
@@ -25,7 +25,7 @@
   clients = "10"
   miners = "3"
   genesis_timestamp_offset = "100000"
-  balance = "2000"
+  balance = "20000000"
 
 [[groups]]
   id = "bootstrapper"

--- a/lotus-soup/compositions/composition-k8s-3-1.toml
+++ b/lotus-soup/compositions/composition-k8s-3-1.toml
@@ -25,7 +25,7 @@
   clients = "3"
   miners = "1"
   genesis_timestamp_offset = "100000"
-  balance = "2000"
+  balance = "20000000"
   sectors = "10"
 
 [[groups]]

--- a/lotus-soup/compositions/composition-k8s-3-2.toml
+++ b/lotus-soup/compositions/composition-k8s-3-2.toml
@@ -25,7 +25,7 @@
   clients = "3"
   miners = "2"
   genesis_timestamp_offset = "100000"
-  balance = "2000"
+  balance = "20000000"
   sectors = "10"
 
 [[groups]]

--- a/lotus-soup/compositions/composition-k8s.toml
+++ b/lotus-soup/compositions/composition-k8s.toml
@@ -25,7 +25,7 @@
   clients = "1"
   miners = "1"
   genesis_timestamp_offset = "100000"
-  balance = "2000"
+  balance = "20000000"
   sectors = "10"
 
 [[groups]]

--- a/lotus-soup/compositions/composition-local-drand.toml
+++ b/lotus-soup/compositions/composition-local-drand.toml
@@ -21,7 +21,7 @@
 [global.run.test_params]
     clients = "1"
     miners = "1"
-    balance = "2000"
+    balance = "20000000"
     sectors = "10"
     random_beacon_type = "local-drand"
     genesis_timestamp_offset = "0"

--- a/lotus-soup/compositions/stress-test-concurrent-natural-k8s.toml
+++ b/lotus-soup/compositions/stress-test-concurrent-natural-k8s.toml
@@ -25,7 +25,7 @@
   clients = "6"
   miners = "2"
   genesis_timestamp_offset = "0"
-  balance = "200000"
+  balance = "20000000"
   sectors = "100"
   random_beacon_type = "mock"
 


### PR DESCRIPTION
Balance of 2000 doesn't work when trying to generate a genesis block on `next`.

I am not sure if this is a bug on Lotus or expected behaviour just yet, but decided to open a PR, in case folks notice that their bootstrapper node fails in the coming days when `next` is merged to `master`.