### PR TITLE
implement Halt/Resume for miner nodes

### DIFF
--- a/lotus-soup/compositions/miner-halt-resume.toml
+++ b/lotus-soup/compositions/miner-halt-resume.toml
@@ -1,0 +1,55 @@
+[metadata]
+  name = "lotus-soup"
+  author = ""
+
+[global]
+  plan = "lotus-soup"
+  case = "deals-e2e"
+  total_instances = 6
+  builder = "exec:go"
+  runner = "local:exec"
+
+[global.build_config]
+  enable_go_build_cache = true
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build]
+  selectors = ["testground"]
+
+[global.run.test_params]
+  clients = "3"
+  miners = "2"
+  genesis_timestamp_offset = "0"
+  balance = "2000000000"
+  sectors = "10"
+  random_beacon_type = "mock"
+
+[[groups]]
+  id = "bootstrapper"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.run]
+    [groups.run.test_params]
+      role = "bootstrapper"
+
+[[groups]]
+  id = "miners"
+  [groups.instances]
+    count = 2
+    percentage = 0.0
+  [groups.run]
+    [groups.run.test_params]
+      role = "miner"
+      suspend_events = "wait 20s -> halt -> wait 30s -> resume"
+
+[[groups]]
+  id = "clients"
+  [groups.instances]
+    count = 3
+    percentage = 0.0
+  [groups.run]
+    [groups.run.test_params]
+      role = "client"

--- a/lotus-soup/go.mod
+++ b/lotus-soup/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.5
 	github.com/testground/sdk-go v0.2.3-0.20200706132230-6a65ddac2d8c
 	go.opencensus.io v0.22.4
+	go.uber.org/fx v1.9.0
 )
 
 // This will work in all build modes: docker:go, exec:go, and local go build.

--- a/lotus-soup/manifest.toml
+++ b/lotus-soup/manifest.toml
@@ -130,9 +130,10 @@ instances = { min = 1, max = 100, default = 5 }
   balance = { type = "float", default = 1 }
   sectors = { type = "int", default = 1 }
   role = { type = "string" }
+
   genesis_timestamp_offset = { type = "int", default = 0 }
 
-  random_beacon_type = { type = "enum", default = "local-drand", options = ["mock", "local-drand", "external-drand"] }
+  random_beacon_type = { type = "enum", default = "mock", options = ["mock", "local-drand", "external-drand"] }
 
   # Params relevant to drand nodes. drand nodes should have role="drand", and must all be
   # in the same composition group. There must be at least threshold drand nodes.

--- a/lotus-soup/testkit/node.go
+++ b/lotus-soup/testkit/node.go
@@ -26,15 +26,26 @@ import (
 
 var PrepareNodeTimeout = time.Minute
 
-type LotusNode struct {
+// FullNode represents a lotus instance, which may be a client, miner, or bootstrapper.
+type FullNode struct {
+	// FullApi is the public API for a lotus node (not including mining-related stuff).
 	FullApi  api.FullNode
+
+	// MinerApi is the public API for storage mining. May be nil if this FullNode is not a miner.
 	MinerApi api.StorageMiner
+
+	// StopFn may be called to graceully shutdown the lotus node. If this node is a miner, the StopFn
+	// will also shutdown the StorageMiner process.
 	StopFn   node.StopFunc
+
+	// Wallet is the nodes private wallet key
 	Wallet   *wallet.Key
+
+	// MineOne is used to advance the synchronized mining process. Will be nil if natural mining is used.
 	MineOne  func(context.Context, func(bool, error)) error
 }
 
-func (n *LotusNode) setWallet(ctx context.Context, walletKey *wallet.Key) error {
+func (n *FullNode) setWallet(ctx context.Context, walletKey *wallet.Key) error {
 	_, err := n.FullApi.WalletImport(ctx, &walletKey.KeyInfo)
 	if err != nil {
 		return err

--- a/lotus-soup/testkit/role_bootstrapper.go
+++ b/lotus-soup/testkit/role_bootstrapper.go
@@ -24,7 +24,7 @@ import (
 // Bootstrapper is a special kind of process that produces a genesis block with
 // the initial wallet balances and preseals for all enlisted miners and clients.
 type Bootstrapper struct {
-	*LotusNode
+	*FullNode
 
 	t *TestEnvironment
 }
@@ -114,7 +114,7 @@ func PrepareBootstrapper(t *TestEnvironment) (*Bootstrapper, error) {
 
 	bootstrapperIP := t.NetClient.MustGetDataNetworkIP().String()
 
-	n := &LotusNode{}
+	n := &FullNode{}
 	stop, err := node.New(context.Background(),
 		node.FullAPI(&n.FullApi),
 		node.Online(),

--- a/lotus-soup/testkit/role_client.go
+++ b/lotus-soup/testkit/role_client.go
@@ -18,7 +18,7 @@ import (
 )
 
 type LotusClient struct {
-	*LotusNode
+	*FullNode
 
 	t          *TestEnvironment
 	MinerAddrs []MinerAddressesMsg
@@ -60,7 +60,7 @@ func PrepareClient(t *TestEnvironment) (*LotusClient, error) {
 	nodeRepo := repo.NewMemory(nil)
 
 	// create the node
-	n := &LotusNode{}
+	n := &FullNode{}
 	stop, err := node.New(context.Background(),
 		node.FullAPI(&n.FullApi),
 		node.Online(),
@@ -133,7 +133,7 @@ func PrepareClient(t *TestEnvironment) (*LotusClient, error) {
 
 	cl := &LotusClient{
 		t:          t,
-		LotusNode:  n,
+		FullNode:   n,
 		MinerAddrs: addrs,
 	}
 	return cl, nil

--- a/lotus-soup/testkit/role_client.go
+++ b/lotus-soup/testkit/role_client.go
@@ -146,7 +146,7 @@ func (c *LotusClient) RunDefault() error {
 	return nil
 }
 
-func startFullNodeAPIServer(t *TestEnvironment, repo *repo.MemRepo, api api.FullNode) error {
+func startFullNodeAPIServer(t *TestEnvironment, repo repo.Repo, api api.FullNode) error {
 	rpcServer := jsonrpc.NewServer()
 	rpcServer.Register("Filecoin", api)
 

--- a/lotus-soup/testkit/role_miner.go
+++ b/lotus-soup/testkit/role_miner.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/lotus/api/apistruct"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/gen"
 	genesis_chain "github.com/filecoin-project/lotus/chain/gen/genesis"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/wallet"
@@ -25,6 +26,7 @@ import (
 	"github.com/filecoin-project/lotus/node"
 	"github.com/filecoin-project/lotus/node/impl"
 	"github.com/filecoin-project/lotus/node/modules"
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
@@ -35,6 +37,9 @@ import (
 	libp2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/testground/sdk-go/sync"
+	"go.uber.org/fx"
+
+	"github.com/filecoin-project/oni/lotus-soup/statemachine"
 )
 
 const (
@@ -45,6 +50,8 @@ type LotusMiner struct {
 	*LotusNode
 
 	t *TestEnvironment
+
+	minerInstance *miner.Miner
 }
 
 func PrepareMiner(t *TestEnvironment) (*LotusMiner, error) {
@@ -114,7 +121,13 @@ func PrepareMiner(t *TestEnvironment) (*LotusMiner, error) {
 		return nil, err
 	}
 
-	// prepare the repo
+	// create the node
+	// we need both a full node _and_ and storage miner node
+	n := &LotusNode{}
+
+	m := &LotusMiner{LotusNode: n, t: t}
+
+	// prepare the repo for the storage miner
 	minerRepo := repo.NewMemory(nil)
 
 	lr, err := minerRepo.Lock(repo.StorageMiner)
@@ -165,10 +178,6 @@ func PrepareMiner(t *TestEnvironment) (*LotusMiner, error) {
 
 	minerIP := t.NetClient.MustGetDataNetworkIP().String()
 
-	// create the node
-	// we need both a full node _and_ and storage miner node
-	n := &LotusNode{}
-
 	nodeRepo := repo.NewMemory(nil)
 
 	stop1, err := node.New(context.Background(),
@@ -202,10 +211,25 @@ func PrepareMiner(t *TestEnvironment) (*LotusMiner, error) {
 		withMinerListenAddress(minerIP),
 	}
 
-	if t.StringParam("mining_mode") != "natural" {
+	if t.StringParam("mining_mode") == "natural" {
+		// call through to default DI module, but capture a reference. gross, but seems to be the only way to get a direct ref to the miner.Miner
+		providerHook := func (lc fx.Lifecycle, ds dtypes.MetadataDS, api api.FullNode, epp gen.WinningPoStProver) (*miner.Miner, error) {
+			var err error
+			m.minerInstance, err = modules.SetupBlockProducer(lc, ds, api, epp)
+			return m.minerInstance, err
+		}
+		minerOpts = append(minerOpts, node.Override(new(*miner.Miner), providerHook))
+	} else {
 		mineBlock := make(chan func(bool, error))
+
+		// wrap the DI module returned by miner.NewTestMiner and grab a ref to the returned miner.Miner
+		providerHook := func(f api.FullNode, p gen.WinningPoStProver) *miner.Miner {
+			m.minerInstance = miner.NewTestMiner(mineBlock, minerAddr)(f, p)
+			return m.minerInstance
+		}
+
 		minerOpts = append(minerOpts,
-			node.Override(new(*miner.Miner), miner.NewTestMiner(mineBlock, minerAddr)))
+			node.Override(new(*miner.Miner), providerHook))
 
 		n.MineOne = func(ctx context.Context, cb func(bool, error)) error {
 			select {
@@ -224,8 +248,11 @@ func PrepareMiner(t *TestEnvironment) (*LotusMiner, error) {
 	}
 	n.StopFn = func(ctx context.Context) error {
 		// TODO use a multierror for this
+		t.RecordMessage("stopping storage miner")
 		err2 := stop2(ctx)
+		t.RecordMessage("storage miner stopped, stopping full node")
 		err1 := stop1(ctx)
+		t.RecordMessage("full node stopped")
 		if err2 != nil {
 			return err2
 		}
@@ -334,8 +361,6 @@ func PrepareMiner(t *TestEnvironment) (*LotusMiner, error) {
 	t.RecordMessage("waiting for all nodes to be ready")
 	t.SyncClient.MustSignalAndWait(ctx, StateReady, t.TestInstanceCount)
 
-	m := &LotusMiner{n, t}
-
 	err = startFullNodeAPIServer(t, nodeRepo, n.FullApi)
 	if err != nil {
 		return nil, err
@@ -419,6 +444,11 @@ func (m *LotusMiner) RunDefault() error {
 		close(done)
 	}
 
+	if t.IsParamSet("suspend_events") {
+		suspender := statemachine.NewSuspender(m, t.RecordMessage)
+		go suspender.RunEvents(t.StringParam("suspend_events"))
+	}
+
 	// wait for a signal from all clients to stop mining
 	err = <-t.SyncClient.MustBarrier(ctx, StateStopMining, clients).C
 	if err != nil {
@@ -432,7 +462,24 @@ func (m *LotusMiner) RunDefault() error {
 	return nil
 }
 
-func startStorageMinerAPIServer(t *TestEnvironment, repo *repo.MemRepo, minerApi api.StorageMiner) error {
+func (m *LotusMiner) Halt() {
+	m.t.RecordMessage("halting miner")
+
+	if err := m.minerInstance.Stop(context.TODO()); err != nil {
+		panic(err)
+	}
+	m.t.RecordMessage("miner halted")
+}
+
+func (m *LotusMiner) Resume() {
+	m.t.RecordMessage("resuming miner")
+	if err := m.minerInstance.Start(context.TODO()); err != nil {
+		panic(fmt.Errorf("failed to resume miner: %s", err))
+	}
+	m.t.RecordMessage("miner resumed")
+}
+
+func startStorageMinerAPIServer(t *TestEnvironment, repo repo.Repo, minerApi api.StorageMiner) error {
 	mux := mux.NewRouter()
 
 	rpcServer := jsonrpc.NewServer()


### PR DESCRIPTION
This pulls out the suspend / resume code from #121 and removes the test plan skeleton I started for the chain recovery scenario.

Now you can add a `suspend_events` param to miner nodes, although currently with synchronized mining you have to halt / resume all miners at once. If you only halt one, the rest will still be waiting on the sync barrier.
