### PR TITLE
Chain state presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ testground plan import --from ./lotus-soup
 5. Init the `filecoin-ffi` Git submodule in the `extra` folder.
 
 ```
-git submodule init
+git submodule update --init --recursive
 ```
 
 6. Compile the `filecoin-ffi` version locally (necessary if you use `local:exec`)

--- a/lotus-soup/rfwp/chain_state.go
+++ b/lotus-soup/rfwp/chain_state.go
@@ -145,7 +145,7 @@ type MinerStateSnapshot struct {
 // writeText marshals m to text and writes to w, swallowing any errors along the way.
 func writeText(w io.Writer, m plainTextMarshaler) {
 	b, err := m.MarshalPlainText()
-	if err == nil {
+	if err != nil {
 		return
 	}
 	_, _ = w.Write(b)

--- a/lotus-soup/rfwp/chain_state.go
+++ b/lotus-soup/rfwp/chain_state.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding"
 	"fmt"
 	"io"
 	"os"
@@ -14,11 +15,13 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/lib/adtutil"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
 
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/apibstore"
 	"github.com/filecoin-project/lotus/chain/types"
+
 	"github.com/filecoin-project/oni/lotus-soup/testkit"
 
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -63,30 +66,35 @@ func ChainState(t *testkit.TestEnvironment, m *testkit.LotusMiner) error {
 				w := bufio.NewWriter(f)
 				defer w.Flush()
 
-				err = info(t, m, maddr, w, tipset.Height())
+				minerInfo, err := info(t, m, maddr, w, tipset.Height())
 				if err != nil {
 					return err
 				}
+				writeText(w, minerInfo)
 
-				err = provingFaults(t, m, maddr, w, tipset.Height())
+				faultState, err := provingFaults(t, m, maddr, tipset.Height())
 				if err != nil {
 					return err
 				}
+				writeText(w, faultState)
 
-				err = provingInfo(t, m, maddr, w, tipset.Height())
+				provState, err := provingInfo(t, m, maddr, tipset.Height())
 				if err != nil {
 					return err
 				}
+				writeText(w, provState)
 
-				err = provingDeadlines(t, m, maddr, w, tipset.Height())
+				deadlines, err := provingDeadlines(t, m, maddr, tipset.Height())
 				if err != nil {
 					return err
 				}
+				writeText(w, deadlines)
 
-				err = sectorsList(t, m, maddr, w, tipset.Height())
+				sectorInfo, err := sectorsList(t, m, maddr, w, tipset.Height())
 				if err != nil {
 					return err
 				}
+				writeText(w, sectorInfo)
 				return nil
 			}()
 			if err != nil {
@@ -98,7 +106,43 @@ func ChainState(t *testkit.TestEnvironment, m *testkit.LotusMiner) error {
 	return nil
 }
 
-func provingFaults(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Address, w io.Writer, height abi.ChainEpoch) error {
+// writeText marshals m to text and writes to w, swallowing any errors along the way.
+func writeText(w io.Writer, m encoding.TextMarshaler) {
+	b, err := m.MarshalText()
+	if err == nil {
+		return
+	}
+	_, _ = w.Write(b)
+}
+
+type ProvingFaultState struct {
+	// FaultedSectors is a map of deadline indices to a list of faulted sectors for that proving window.
+	// If the miner has no faulty sectors, the map will be empty.
+	FaultedSectors map[int][]uint64
+}
+
+func (s *ProvingFaultState) MarshalText() ([]byte, error) {
+	w := &bytes.Buffer{}
+
+	if len(s.FaultedSectors) == 0 {
+		fmt.Fprintf(w, "no faulty sectors\n")
+		return w.Bytes(), nil
+	}
+
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintf(tw, "deadline\tsectors")
+	for deadline := 0; deadline < int(miner.WPoStPeriodDeadlines); deadline++ {
+		if sectors, ok := s.FaultedSectors[deadline]; ok {
+			for _, num := range sectors {
+				_, _ = fmt.Fprintf(tw, "%d\t%d\n", deadline, num)
+			}
+		}
+	}
+
+	return w.Bytes(), nil
+}
+
+func provingFaults(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Address, height abi.ChainEpoch) (*ProvingFaultState, error) {
 	api := m.FullApi
 	ctx := context.Background()
 
@@ -106,102 +150,149 @@ func provingFaults(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr addr
 	{
 		mact, err := api.StateGetActor(ctx, maddr, types.EmptyTSK)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		rmas, err := api.ChainReadObj(ctx, mact.Head)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if err := mas.UnmarshalCBOR(bytes.NewReader(rmas)); err != nil {
-			return err
+			return nil, err
 		}
 	}
 	faults, err := mas.Faults.All(100000000000)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	s := ProvingFaultState{FaultedSectors: make(map[int][]uint64)}
+
 	if len(faults) == 0 {
-		fmt.Fprintf(w, "no faulty sectors\n")
-		return nil
+		return &s, nil
 	}
 	head, err := api.ChainHead(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	deadlines, err := api.StateMinerDeadlines(ctx, maddr, head.Key())
 	if err != nil {
-		return err
+		return nil, err
 	}
-	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintf(tw, "deadline\tsectors")
+
 	for deadline, sectors := range deadlines.Due {
 		intersectSectors, _ := bitfield.IntersectBitField(sectors, mas.Faults)
 		if intersectSectors != nil {
 			allSectors, _ := intersectSectors.All(100000000000)
 			for _, num := range allSectors {
-				_, _ = fmt.Fprintf(tw, "%d\t%d\n", deadline, num)
+				s.FaultedSectors[deadline] = append(s.FaultedSectors[deadline], num)
 			}
 		}
 
 	}
-	tw.Flush()
-	return nil
+	return &s, nil
 }
 
-func provingInfo(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Address, w io.Writer, height abi.ChainEpoch) error {
+type ProvingInfoState struct {
+	CurrentEpoch abi.ChainEpoch
+
+	ProvingPeriodStart abi.ChainEpoch
+
+	Faults        uint64
+	ProvenSectors uint64
+	FaultPercent  float64
+	Recoveries    uint64
+	NewSectors    uint64
+
+	DeadlineIndex       uint64
+	DeadlineSectors     uint64
+	DeadlineOpen        abi.ChainEpoch
+	DeadlineClose       abi.ChainEpoch
+	DeadlineChallenge   abi.ChainEpoch
+	DeadlineFaultCutoff abi.ChainEpoch
+
+	WPoStProvingPeriod abi.ChainEpoch
+}
+
+func (s *ProvingInfoState) MarshalText() ([]byte, error) {
+	w := &bytes.Buffer{}
+	fmt.Fprintf(w, "Current Epoch:           %d\n", s.CurrentEpoch)
+	fmt.Fprintf(w, "Chain Period:            %d\n", s.CurrentEpoch/s.WPoStProvingPeriod)
+	fmt.Fprintf(w, "Chain Period Start:      %s\n", epochTime(s.CurrentEpoch, (s.CurrentEpoch/s.WPoStProvingPeriod)*s.WPoStProvingPeriod))
+	fmt.Fprintf(w, "Chain Period End:        %s\n\n", epochTime(s.CurrentEpoch, (s.CurrentEpoch/s.WPoStProvingPeriod+1)*s.WPoStProvingPeriod))
+
+	fmt.Fprintf(w, "Proving Period Boundary: %d\n", s.ProvingPeriodStart%s.WPoStProvingPeriod)
+	fmt.Fprintf(w, "Proving Period Start:    %s\n", epochTime(s.CurrentEpoch, s.ProvingPeriodStart))
+	fmt.Fprintf(w, "Next Period Start:       %s\n\n", epochTime(s.CurrentEpoch, s.ProvingPeriodStart+s.WPoStProvingPeriod))
+
+	fmt.Fprintf(w, "Faults:      %d (%.2f%%)\n", s.Faults, s.FaultPercent)
+	fmt.Fprintf(w, "Recovering:  %d\n", s.Recoveries)
+	fmt.Fprintf(w, "New Sectors: %d\n\n", s.NewSectors)
+
+	fmt.Fprintf(w, "Deadline Index:       %d\n", s.DeadlineIndex)
+	fmt.Fprintf(w, "Deadline Sectors:     %d\n", s.DeadlineSectors)
+
+	fmt.Fprintf(w, "Deadline Open:        %s\n", epochTime(s.CurrentEpoch, s.DeadlineOpen))
+	fmt.Fprintf(w, "Deadline Close:       %s\n", epochTime(s.CurrentEpoch, s.DeadlineClose))
+	fmt.Fprintf(w, "Deadline Challenge:   %s\n", epochTime(s.CurrentEpoch, s.DeadlineChallenge))
+	fmt.Fprintf(w, "Deadline FaultCutoff: %s\n", epochTime(s.CurrentEpoch, s.DeadlineFaultCutoff))
+
+	return w.Bytes(), nil
+}
+
+func provingInfo(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Address, height abi.ChainEpoch) (*ProvingInfoState, error) {
 	api := m.FullApi
 	ctx := context.Background()
 
 	head, err := api.ChainHead(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	cd, err := api.StateMinerProvingDeadline(ctx, maddr, head.Key())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	deadlines, err := api.StateMinerDeadlines(ctx, maddr, head.Key())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var mas miner.State
 	{
 		mact, err := api.StateGetActor(ctx, maddr, types.EmptyTSK)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		rmas, err := api.ChainReadObj(ctx, mact.Head)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if err := mas.UnmarshalCBOR(bytes.NewReader(rmas)); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	newSectors, err := mas.NewSectors.Count()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	faults, err := mas.Faults.Count()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	recoveries, err := mas.Recoveries.Count()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var provenSectors uint64
 	for _, d := range deadlines.Due {
 		c, err := d.Count()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		provenSectors += c
 	}
@@ -211,34 +302,30 @@ func provingInfo(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr addres
 		faultPerc = float64(faults*10000/provenSectors) / 100
 	}
 
-	fmt.Fprintf(w, "Current Epoch:           %d\n", cd.CurrentEpoch)
-	fmt.Fprintf(w, "Chain Period:            %d\n", cd.CurrentEpoch/miner.WPoStProvingPeriod)
-	fmt.Fprintf(w, "Chain Period Start:      %s\n", epochTime(cd.CurrentEpoch, (cd.CurrentEpoch/miner.WPoStProvingPeriod)*miner.WPoStProvingPeriod))
-	fmt.Fprintf(w, "Chain Period End:        %s\n\n", epochTime(cd.CurrentEpoch, (cd.CurrentEpoch/miner.WPoStProvingPeriod+1)*miner.WPoStProvingPeriod))
-
-	fmt.Fprintf(w, "Proving Period Boundary: %d\n", cd.PeriodStart%miner.WPoStProvingPeriod)
-	fmt.Fprintf(w, "Proving Period Start:    %s\n", epochTime(cd.CurrentEpoch, cd.PeriodStart))
-	fmt.Fprintf(w, "Next Period Start:       %s\n\n", epochTime(cd.CurrentEpoch, cd.PeriodStart+miner.WPoStProvingPeriod))
-
-	fmt.Fprintf(w, "Faults:      %d (%.2f%%)\n", faults, faultPerc)
-	fmt.Fprintf(w, "Recovering:  %d\n", recoveries)
-	fmt.Fprintf(w, "New Sectors: %d\n\n", newSectors)
-
-	fmt.Fprintf(w, "Deadline Index:       %d\n", cd.Index)
-
+	s := ProvingInfoState{
+		CurrentEpoch:        cd.CurrentEpoch,
+		ProvingPeriodStart:  cd.PeriodStart,
+		Faults:              faults,
+		ProvenSectors:       provenSectors,
+		FaultPercent:        faultPerc,
+		Recoveries:          recoveries,
+		NewSectors:          newSectors,
+		DeadlineIndex:       cd.Index,
+		DeadlineOpen:        cd.Open,
+		DeadlineClose:       cd.Close,
+		DeadlineChallenge:   cd.Challenge,
+		DeadlineFaultCutoff: cd.FaultCutoff,
+		WPoStProvingPeriod:  miner.WPoStProvingPeriod,
+	}
 	if cd.Index < uint64(len(deadlines.Due)) {
 		curDeadlineSectors, err := deadlines.Due[cd.Index].Count()
 		if err != nil {
-			return err
+			return nil, err
 		}
-		fmt.Fprintf(w, "Deadline Sectors:     %d\n", curDeadlineSectors)
+		s.DeadlineSectors = curDeadlineSectors
 	}
 
-	fmt.Fprintf(w, "Deadline Open:        %s\n", epochTime(cd.CurrentEpoch, cd.Open))
-	fmt.Fprintf(w, "Deadline Close:       %s\n", epochTime(cd.CurrentEpoch, cd.Close))
-	fmt.Fprintf(w, "Deadline Challenge:   %s\n", epochTime(cd.CurrentEpoch, cd.Challenge))
-	fmt.Fprintf(w, "Deadline FaultCutoff: %s\n", epochTime(cd.CurrentEpoch, cd.FaultCutoff))
-	return nil
+	return &s, nil
 }
 
 func epochTime(curr, e abi.ChainEpoch) string {
@@ -254,18 +341,45 @@ func epochTime(curr, e abi.ChainEpoch) string {
 	panic("math broke")
 }
 
-func provingDeadlines(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Address, w io.Writer, height abi.ChainEpoch) error {
+type ProvingDeadlines struct {
+	Deadlines []DeadlineInfo
+}
+
+type DeadlineInfo struct {
+	Sectors uint64
+	Partitions uint64
+	Proven uint64
+	Current bool
+}
+
+func (d *ProvingDeadlines) MarshalText() ([]byte, error) {
+	w := new(bytes.Buffer)
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "deadline\tsectors\tpartitions\tproven")
+
+	for i, di := range d.Deadlines {
+		var cur string
+		if di.Current {
+			cur += "\t(current)"
+		}
+		_, _ = fmt.Fprintf(tw, "%d\t%d\t%d\t%d%s\n", i, di.Sectors, di.Partitions, di.Proven, cur)
+	}
+	tw.Flush()
+	return w.Bytes(), nil
+}
+
+func provingDeadlines(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Address, height abi.ChainEpoch) (*ProvingDeadlines, error) {
 	api := m.FullApi
 	ctx := context.Background()
 
 	deadlines, err := api.StateMinerDeadlines(ctx, maddr, types.EmptyTSK)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	di, err := api.StateMinerProvingDeadline(ctx, maddr, types.EmptyTSK)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var mas miner.State
@@ -273,34 +387,32 @@ func provingDeadlines(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr a
 	{
 		mact, err := api.StateGetActor(ctx, maddr, types.EmptyTSK)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		rmas, err := api.ChainReadObj(ctx, mact.Head)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if err := mas.UnmarshalCBOR(bytes.NewReader(rmas)); err != nil {
-			return err
+			return nil, err
 		}
 
 		info, err = mas.GetInfo(adtutil.NewStore(ctx, cbor.NewCborStore(apibstore.NewAPIBlockstore(api))))
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "deadline\tsectors\tpartitions\tproven")
-
+	infos := make([]DeadlineInfo, len(deadlines.Due))
 	for i, field := range deadlines.Due {
 		c, err := field.Count()
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		firstPartition, sectorCount, err := miner.PartitionsForDeadline(deadlines, info.WindowPoStPartitionSectors, uint64(i))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		partitionCount := (sectorCount + info.WindowPoStPartitionSectors - 1) / info.WindowPoStPartitionSectors
@@ -321,72 +433,60 @@ func provingDeadlines(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr a
 
 			ppbm, err := bitfield.NewFromIter(&rlepluslazy.RunSliceIterator{Runs: maskRuns})
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			pp, err := bitfield.IntersectBitField(ppbm, mas.PostSubmissions)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			provenPartitions, err = pp.Count()
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 
-		var cur string
-		if di.Index == uint64(i) {
-			cur += "\t(current)"
+		outInfo := DeadlineInfo{
+			Sectors:    c,
+			Partitions: partitionCount,
+			Proven:     provenPartitions,
+			Current:    di.Index == uint64(i),
 		}
-		_, _ = fmt.Fprintf(tw, "%d\t%d\t%d\t%d%s\n", i, c, partitionCount, provenPartitions, cur)
+		infos = append(infos, outInfo)
 	}
 
-	return tw.Flush()
+	return &ProvingDeadlines{Deadlines: infos}, nil
 }
 
-func sectorsList(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Address, w io.Writer, height abi.ChainEpoch) error {
-	api := m.FullApi
-	ctx := context.Background()
+type SectorInfo struct {
+	Sectors []abi.SectorNumber
+	SectorStates map[abi.SectorNumber]api.SectorInfo
+	Committed []abi.SectorNumber
+	Proving []abi.SectorNumber
+}
 
-	list, err := m.MinerApi.SectorsList(ctx)
-	if err != nil {
-		return err
+func (i *SectorInfo) MarshalText() ([]byte, error) {
+	provingIDs := make(map[abi.SectorNumber]struct{}, len(i.Proving))
+	for _, id := range i.Proving {
+		provingIDs[id] = struct{}{}
+	}
+	commitedIDs := make(map[abi.SectorNumber]struct{}, len(i.Committed))
+	for _, id := range i.Committed {
+		commitedIDs[id] = struct{}{}
 	}
 
-	pset, err := api.StateMinerProvingSet(ctx, maddr, types.EmptyTSK)
-	if err != nil {
-		return err
-	}
-	provingIDs := make(map[abi.SectorNumber]struct{}, len(pset))
-	for _, info := range pset {
-		provingIDs[info.ID] = struct{}{}
-	}
-
-	sset, err := api.StateMinerSectors(ctx, maddr, nil, true, types.EmptyTSK)
-	if err != nil {
-		return err
-	}
-	commitedIDs := make(map[abi.SectorNumber]struct{}, len(pset))
-	for _, info := range sset {
-		commitedIDs[info.ID] = struct{}{}
-	}
-
-	sort.Slice(list, func(i, j int) bool {
-		return list[i] < list[j]
-	})
-
+	w := new(bytes.Buffer)
 	tw := tabwriter.NewWriter(w, 8, 4, 1, ' ', 0)
 
-	for _, s := range list {
-		st, err := m.MinerApi.SectorsStatus(ctx, s)
-		if err != nil {
-			fmt.Fprintf(w, "%d:\tError: %s\n", s, err)
-			continue
-		}
-
+	for _, s := range i.Sectors {
 		_, inSSet := commitedIDs[s]
 		_, inPSet := provingIDs[s]
+
+		st, ok := i.SectorStates[s]
+		if !ok {
+			continue
+		}
 
 		fmt.Fprintf(tw, "%d: %s\tsSet: %s\tpSet: %s\ttktH: %d\tseedH: %d\tdeals: %v\n",
 			s,
@@ -399,7 +499,55 @@ func sectorsList(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr addres
 		)
 	}
 
-	return tw.Flush()
+	if err := tw.Flush(); err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
+}
+
+func sectorsList(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Address, w io.Writer, height abi.ChainEpoch) (*SectorInfo, error) {
+	node := m.FullApi
+	ctx := context.Background()
+
+	list, err := m.MinerApi.SectorsList(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i] < list[j]
+	})
+
+	i := SectorInfo{Sectors: list, SectorStates: make(map[abi.SectorNumber]api.SectorInfo, len(list))}
+
+	pset, err := node.StateMinerProvingSet(ctx, maddr, types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+	for _, info := range pset {
+		i.Proving = append(i.Proving, info.ID)
+	}
+
+	sset, err := node.StateMinerSectors(ctx, maddr, nil, true, types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+	for _, info := range sset {
+		i.Committed = append(i.Committed, info.ID)
+	}
+
+	sort.Slice(list, func(i, j int) bool {
+		return list[i] < list[j]
+	})
+
+	for _, s := range list {
+		st, err := m.MinerApi.SectorsStatus(ctx, s)
+		if err != nil {
+			fmt.Fprintf(w, "%d:\tError: %s\n", s, err)
+			continue
+		}
+		i.SectorStates[s] = st
+	}
+	return &i, nil
 }
 
 func yesno(b bool) string {
@@ -409,40 +557,34 @@ func yesno(b bool) string {
 	return "NO"
 }
 
-func info(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Address, w io.Writer, height abi.ChainEpoch) error {
-	api := m.FullApi
-	ctx := context.Background()
+type MinerInfo struct {
+	MinerAddr  address.Address
+	SectorSize string
 
-	mact, err := api.StateGetActor(ctx, maddr, types.EmptyTSK)
-	if err != nil {
-		return err
-	}
-	var mas miner.State
-	{
-		rmas, err := api.ChainReadObj(ctx, mact.Head)
-		if err != nil {
-			return err
-		}
-		if err := mas.UnmarshalCBOR(bytes.NewReader(rmas)); err != nil {
-			return err
-		}
-	}
+	MinerPower *api.MinerPower
 
-	fmt.Fprintf(w, "Miner: %s\n", maddr)
+	CommittedBytes   big.Int
+	ProvingBytes     big.Int
+	FaultyBytes      big.Int
+	FaultyPercentage float64
 
-	// Sector size
-	mi, err := api.StateMinerInfo(ctx, maddr, types.EmptyTSK)
-	if err != nil {
-		return err
-	}
+	Balance           big.Int
+	PreCommitDeposits big.Int
+	LockedFunds       big.Int
+	AvailableFunds    big.Int
+	WorkerBalance     big.Int
+	MarketEscrow      big.Int
+	MarketLocked      big.Int
 
-	fmt.Fprintf(w, "Sector Size: %s\n", types.SizeStr(types.NewInt(uint64(mi.SectorSize))))
+	SectorStateCounts map[sealing.SectorState]int
+}
 
-	pow, err := api.StateMinerPower(ctx, maddr, types.EmptyTSK)
-	if err != nil {
-		return err
-	}
+func (i *MinerInfo) MarshalText() ([]byte, error) {
+	w := new(bytes.Buffer)
+	fmt.Fprintf(w, "Miner: %s\n", i.MinerAddr)
+	fmt.Fprintf(w, "Sector Size: %s\n", i.SectorSize)
 
+	pow := i.MinerPower
 	rpercI := types.BigDiv(types.BigMul(pow.MinerPower.RawBytePower, types.NewInt(1000000)), pow.TotalPower.RawBytePower)
 	qpercI := types.BigDiv(types.BigMul(pow.MinerPower.QualityAdjPower, types.NewInt(1000000)), pow.TotalPower.QualityAdjPower)
 
@@ -456,35 +598,18 @@ func info(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Addre
 		types.DeciStr(pow.TotalPower.QualityAdjPower),
 		float64(qpercI.Int64())/10000)
 
-	secCounts, err := api.StateMinerSectorCount(ctx, maddr, types.EmptyTSK)
-	if err != nil {
-		return err
-	}
-	faults, err := api.StateMinerFaults(ctx, maddr, types.EmptyTSK)
-	if err != nil {
-		return err
-	}
+	fmt.Fprintf(w, "\tCommitted: %s\n", types.SizeStr(i.CommittedBytes))
 
-	nfaults, err := faults.Count()
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(w, "\tCommitted: %s\n", types.SizeStr(types.BigMul(types.NewInt(secCounts.Sset), types.NewInt(uint64(mi.SectorSize)))))
-	if nfaults == 0 {
-		fmt.Fprintf(w, "\tProving: %s\n", types.SizeStr(types.BigMul(types.NewInt(secCounts.Pset), types.NewInt(uint64(mi.SectorSize)))))
+	if i.FaultyBytes.IsZero() {
+		fmt.Fprintf(w, "\tProving: %s\n", types.SizeStr(i.ProvingBytes))
 	} else {
-		var faultyPercentage float64
-		if secCounts.Sset != 0 {
-			faultyPercentage = float64(10000*nfaults/secCounts.Sset) / 100.
-		}
 		fmt.Fprintf(w, "\tProving: %s (%s Faulty, %.2f%%)\n",
-			types.SizeStr(types.BigMul(types.NewInt(secCounts.Pset), types.NewInt(uint64(mi.SectorSize)))),
-			types.SizeStr(types.BigMul(types.NewInt(nfaults), types.NewInt(uint64(mi.SectorSize)))),
-			faultyPercentage)
+			types.SizeStr(i.ProvingBytes),
+			types.SizeStr(i.FaultyBytes),
+			i.FaultyPercentage)
 	}
 
-	if pow.MinerPower.RawBytePower.LessThan(power.ConsensusMinerMinPower) {
+	if i.MinerPower.MinerPower.RawBytePower.LessThan(power.ConsensusMinerMinPower) {
 		fmt.Fprintf(w, "Below minimum power threshold, no blocks will be won\n")
 	} else {
 		expWinChance := float64(types.BigMul(qpercI, types.NewInt(build.BlocksPerEpoch)).Int64()) / 1000000
@@ -501,49 +626,16 @@ func info(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Addre
 	}
 
 	fmt.Println()
-
-	fmt.Fprintf(w, "Miner Balance: %s\n", types.FIL(mact.Balance))
-	fmt.Fprintf(w, "\tPreCommit:   %s\n", types.FIL(mas.PreCommitDeposits))
-	fmt.Fprintf(w, "\tLocked:      %s\n", types.FIL(mas.LockedFunds))
-	fmt.Fprintf(w, "\tAvailable:   %s\n", types.FIL(types.BigSub(mact.Balance, types.BigAdd(mas.LockedFunds, mas.PreCommitDeposits))))
-	wb, err := api.WalletBalance(ctx, mi.Worker)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(w, "Worker Balance: %s\n", types.FIL(wb))
-
-	mb, err := api.StateMarketBalance(ctx, maddr, types.EmptyTSK)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(w, "Market (Escrow):  %s\n", types.FIL(mb.Escrow))
-	fmt.Fprintf(w, "Market (Locked):  %s\n\n", types.FIL(mb.Locked))
+	fmt.Fprintf(w, "Miner Balance: %s\n", types.FIL(i.Balance))
+	fmt.Fprintf(w, "\tPreCommit:   %s\n", types.FIL(i.PreCommitDeposits))
+	fmt.Fprintf(w, "\tLocked:      %s\n", types.FIL(i.LockedFunds))
+	fmt.Fprintf(w, "\tAvailable:   %s\n", types.FIL(i.AvailableFunds))
+	fmt.Fprintf(w, "Worker Balance: %s\n", types.FIL(i.WorkerBalance))
+	fmt.Fprintf(w, "Market (Escrow):  %s\n", types.FIL(i.MarketEscrow))
+	fmt.Fprintf(w, "Market (Locked):  %s\n\n", types.FIL(i.MarketLocked))
 
 	fmt.Println("Sectors:")
-	err = sectorsInfo(ctx, w, m.MinerApi)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func sectorsInfo(ctx context.Context, w io.Writer, napi api.StorageMiner) error {
-	sectors, err := napi.SectorsList(ctx)
-	if err != nil {
-		return err
-	}
-
-	buckets := map[sealing.SectorState]int{
-		"Total": len(sectors),
-	}
-	for _, s := range sectors {
-		st, err := napi.SectorsStatus(ctx, s)
-		if err != nil {
-			return err
-		}
-
-		buckets[sealing.SectorState(st.State)]++
-	}
+	buckets := i.SectorStateCounts
 
 	var sorted []stateMeta
 	for state, i := range buckets {
@@ -558,7 +650,104 @@ func sectorsInfo(ctx context.Context, w io.Writer, napi api.StorageMiner) error 
 		_, _ = fmt.Fprintf(w, "\t%s: %d\n", s.state, s.i)
 	}
 
-	return nil
+	return w.Bytes(), nil
+}
+
+func info(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Address, w io.Writer, height abi.ChainEpoch) (*MinerInfo, error) {
+	api := m.FullApi
+	ctx := context.Background()
+
+	mact, err := api.StateGetActor(ctx, maddr, types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+	var mas miner.State
+	{
+		rmas, err := api.ChainReadObj(ctx, mact.Head)
+		if err != nil {
+			return nil, err
+		}
+		if err := mas.UnmarshalCBOR(bytes.NewReader(rmas)); err != nil {
+			return nil, err
+		}
+	}
+
+	i := MinerInfo{MinerAddr: maddr}
+
+	// Sector size
+	mi, err := api.StateMinerInfo(ctx, maddr, types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+
+	i.SectorSize = types.SizeStr(types.NewInt(uint64(mi.SectorSize)))
+
+	i.MinerPower, err = api.StateMinerPower(ctx, maddr, types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+
+	secCounts, err := api.StateMinerSectorCount(ctx, maddr, types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+	faults, err := api.StateMinerFaults(ctx, maddr, types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+
+	nfaults, err := faults.Count()
+	if err != nil {
+		return nil, err
+	}
+
+	i.CommittedBytes = types.BigMul(types.NewInt(secCounts.Sset), types.NewInt(uint64(mi.SectorSize)))
+	i.ProvingBytes = types.BigMul(types.NewInt(secCounts.Pset), types.NewInt(uint64(mi.SectorSize)))
+
+	if nfaults != 0 {
+		if secCounts.Sset != 0 {
+			i.FaultyPercentage = float64(10000*nfaults/secCounts.Sset) / 100.
+		}
+		i.FaultyBytes = types.BigMul(types.NewInt(nfaults), types.NewInt(uint64(mi.SectorSize)))
+	}
+
+	i.Balance = mact.Balance
+	i.PreCommitDeposits = mas.PreCommitDeposits
+	i.LockedFunds = mas.LockedFunds
+	i.AvailableFunds = types.BigSub(mact.Balance, types.BigAdd(mas.LockedFunds, mas.PreCommitDeposits))
+
+	wb, err := api.WalletBalance(ctx, mi.Worker)
+	if err != nil {
+		return nil, err
+	}
+	i.WorkerBalance = wb
+
+	mb, err := api.StateMarketBalance(ctx, maddr, types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+	i.MarketEscrow = mb.Escrow
+	i.MarketLocked = mb.Locked
+
+	sectors, err := m.MinerApi.SectorsList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	buckets := map[sealing.SectorState]int{
+		"Total": len(sectors),
+	}
+	for _, s := range sectors {
+		st, err := m.MinerApi.SectorsStatus(ctx, s)
+		if err != nil {
+			return nil, err
+		}
+
+		buckets[sealing.SectorState(st.State)]++
+	}
+	i.SectorStateCounts = buckets
+
+	return &i, nil
 }
 
 type stateMeta struct {


### PR DESCRIPTION
@nonsense this builds on your branch to pull the chain state into structs that we can marshal as both plain text and json. It writes a newline-delimited `chain-state.ndjson` with a line for each epoch, as well as the state files you were already writing. I think we should keep those since they're nice and human readable and good for quick debugging.

I didn't have much time to play with the data & load into jupyter, so I don't know if the shape of the json is exactly what we want yet. But we can always tweak it.
