### PR TITLE
generate html state on each tipset

### DIFF
--- a/lotus-soup/go.mod
+++ b/lotus-soup/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/filecoin-project/go-fil-markets v0.4.1-0.20200715201050-c141144ea312
 	github.com/filecoin-project/go-jsonrpc v0.1.1-0.20200602181149-522144ab4e24
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
-	github.com/filecoin-project/lotus v0.4.2-0.20200721105801-e21ea5355f64
+	github.com/filecoin-project/lotus v0.4.2-0.20200721172325-54f1f6b8c9ef
 	github.com/filecoin-project/specs-actors v0.8.1-0.20200721133408-d1ddf5fc315b
 	github.com/filecoin-project/storage-fsm v0.0.0-20200720190000-2cfe2fe3c334
 	github.com/gorilla/mux v1.7.4

--- a/lotus-soup/go.sum
+++ b/lotus-soup/go.sum
@@ -265,6 +265,10 @@ github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b 
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
 github.com/filecoin-project/lotus v0.4.2-0.20200721105801-e21ea5355f64 h1:eGBymDewiMz2wXXrTQJyjxtVJP1jYD+HKZtebkbjU68=
 github.com/filecoin-project/lotus v0.4.2-0.20200721105801-e21ea5355f64/go.mod h1:jubu0DGUMhIy/0l5HZNzKXgANucmSTLXLUAhVvVrj58=
+github.com/filecoin-project/lotus v0.4.2-0.20200721164738-9154939d8fb4 h1:j14t2oPBZXkzm3GBlJapDuHj17KHIupThP05WLjdG9g=
+github.com/filecoin-project/lotus v0.4.2-0.20200721164738-9154939d8fb4/go.mod h1:jubu0DGUMhIy/0l5HZNzKXgANucmSTLXLUAhVvVrj58=
+github.com/filecoin-project/lotus v0.4.2-0.20200721172325-54f1f6b8c9ef h1:u/jI9vlqKsdRSgs34AyssiqTH2yL/4r2+qwnrmcqF6s=
+github.com/filecoin-project/lotus v0.4.2-0.20200721172325-54f1f6b8c9ef/go.mod h1:jubu0DGUMhIy/0l5HZNzKXgANucmSTLXLUAhVvVrj58=
 github.com/filecoin-project/sector-storage v0.0.0-20200615154852-728a47ab99d6/go.mod h1:M59QnAeA/oV+Z8oHFLoNpGMv0LZ8Rll+vHVXX7GirPM=
 github.com/filecoin-project/sector-storage v0.0.0-20200712023225-1d67dcfa3c15/go.mod h1:salgVdX7qeXFo/xaiEQE29J4pPkjn71T0kt0n+VDBzo=
 github.com/filecoin-project/sector-storage v0.0.0-20200717213554-a109ef9cbeab h1:jEQtbWFyEKnCw3eAVCW3MSX/K7Nv03B3zzS/rfm2k+Q=

--- a/lotus-soup/rfwp/e2e.go
+++ b/lotus-soup/rfwp/e2e.go
@@ -47,6 +47,10 @@ func handleMiner(t *testkit.TestEnvironment) error {
 
 	t.RecordMessage("running miner: %s", myActorAddr)
 
+	if t.GroupSeq == 1 {
+		go FetchChainState(t, m)
+	}
+
 	go UpdateChainState(t, m)
 
 	// wait for a signal from 1 client to expect slashing

--- a/lotus-soup/rfwp/html_chain_state.go
+++ b/lotus-soup/rfwp/html_chain_state.go
@@ -1,0 +1,66 @@
+package rfwp
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/filecoin-project/oni/lotus-soup/testkit"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/cli"
+	tstats "github.com/filecoin-project/lotus/tools/stats"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/ipfs/go-cid"
+)
+
+func FetchChainState(t *testkit.TestEnvironment, m *testkit.LotusMiner) error {
+	height := 0
+	headlag := 3
+
+	ctx := context.Background()
+	api := m.FullApi
+
+	tipsetsCh, err := tstats.GetTips(ctx, m.FullApi, abi.ChainEpoch(height), headlag)
+	if err != nil {
+		return err
+	}
+
+	for tipset := range tipsetsCh {
+		err := func() error {
+			filename := fmt.Sprintf("%s%cchain-state-%d.html", t.TestOutputsPath, os.PathSeparator, tipset.Height())
+			file, err := os.Create(filename)
+			defer file.Close()
+			if err != nil {
+				return err
+			}
+
+			stout, err := api.StateCompute(ctx, tipset.Height(), nil, tipset.Key())
+			if err != nil {
+				return err
+			}
+
+			codeCache := map[address.Address]cid.Cid{}
+			getCode := func(addr address.Address) (cid.Cid, error) {
+				if c, found := codeCache[addr]; found {
+					return c, nil
+				}
+
+				c, err := api.StateGetActor(ctx, addr, tipset.Key())
+				if err != nil {
+					return cid.Cid{}, err
+				}
+
+				codeCache[addr] = c.Code
+				return c.Code, nil
+			}
+
+			return cli.ComputeStateHTMLTempl(file, tipset, stout, getCode)
+		}()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR is adding another hook to the `ChainNotify` so that we generate an HTML view of the state on each tipset.

This will be helpful when trying to understand what happened in a given tipset - for example see if there are payment channel messages emitted around the time we do a retrieval, so that we know if a payment channel is setup correctly.