### PR TITLE
Offline deal flow / dumbo drop 

### DIFF
--- a/lotus-soup/_compositions/deals-offline-k8s.toml
+++ b/lotus-soup/_compositions/deals-offline-k8s.toml
@@ -42,7 +42,8 @@
 [[groups]]
   id = "miners"
   [groups.resources]
-    memory = "1600Mi"
+    cpu = "4000m"
+    memory = "8000Mi"
   [groups.instances]
     count = 1
     percentage = 0.0
@@ -53,6 +54,7 @@
 [[groups]]
   id = "clients"
   [groups.resources]
+      cpu = "3000m"
       memory = "4000Mi"
   [groups.instances]
     count = 1
@@ -60,6 +62,6 @@
   [groups.run]
     [groups.run.test_params]
       role = "client"
-      deals = "12000"
+      deals = "2500000"
       deal_start_epoch = "1000000"
       balance = "800000000"

--- a/lotus-soup/_compositions/deals-offline-k8s.toml
+++ b/lotus-soup/_compositions/deals-offline-k8s.toml
@@ -43,7 +43,7 @@
   id = "miners"
   [groups.resources]
     cpu = "4000m"
-    memory = "8000Mi"
+    memory = "12000Mi"
   [groups.instances]
     count = 1
     percentage = 0.0
@@ -54,8 +54,8 @@
 [[groups]]
   id = "clients"
   [groups.resources]
-      cpu = "3000m"
-      memory = "4000Mi"
+      cpu = "4000m"
+      memory = "12000Mi"
   [groups.instances]
     count = 1
     percentage = 0.0

--- a/lotus-soup/_compositions/deals-offline-k8s.toml
+++ b/lotus-soup/_compositions/deals-offline-k8s.toml
@@ -30,6 +30,8 @@
 
 [[groups]]
   id = "bootstrapper"
+  [groups.resources]
+      memory = "2000Mi"
   [groups.instances]
     count = 1
     percentage = 0.0
@@ -39,6 +41,8 @@
 
 [[groups]]
   id = "miners"
+  [groups.resources]
+    memory = "1600Mi"
   [groups.instances]
     count = 1
     percentage = 0.0
@@ -48,6 +52,8 @@
 
 [[groups]]
   id = "clients"
+  [groups.resources]
+      memory = "4000Mi"
   [groups.instances]
     count = 1
     percentage = 0.0

--- a/lotus-soup/_compositions/deals-offline-k8s.toml
+++ b/lotus-soup/_compositions/deals-offline-k8s.toml
@@ -7,7 +7,7 @@
   case = "deals-offline"
   total_instances = 3
   builder = "docker:go"
-  runner = "local:docker"
+  runner = "cluster:k8s"
 
 [global.build]
   selectors = ["testground"]
@@ -16,7 +16,8 @@
   exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
 
 [global.build_config]
-  enable_go_build_cache = true
+  push_registry=true
+  registry_type="aws"
 
 [global.run.test_params]
   clients = "1"

--- a/lotus-soup/_compositions/deals-offline.toml
+++ b/lotus-soup/_compositions/deals-offline.toml
@@ -1,0 +1,58 @@
+[metadata]
+  name = "lotus-soup"
+  author = ""
+
+[global]
+  plan = "lotus-soup"
+  case = "deals-offline"
+  total_instances = 3
+  builder = "docker:go"
+  runner = "local:docker"
+
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  enable_go_build_cache = true
+
+[global.run.test_params]
+  clients = "1"
+  miners = "1"
+  genesis_timestamp_offset = "0"
+  balance = "800000000"
+  sectors = "5"
+  random_beacon_type = "mock"
+  mining_mode = "natural"
+
+[[groups]]
+  id = "bootstrapper"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.run]
+    [groups.run.test_params]
+      role = "bootstrapper"
+
+[[groups]]
+  id = "miners"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.run]
+    [groups.run.test_params]
+      role = "miner"
+
+[[groups]]
+  id = "clients"
+  [groups.instances]
+    count = 1
+    percentage = 0.0
+  [groups.run]
+    [groups.run.test_params]
+      role = "client"
+      deals = "12000"
+      deal_start_epoch = "100000"
+      balance = "800000000"

--- a/lotus-soup/deals_offline.go
+++ b/lotus-soup/deals_offline.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"math/rand"
+	"time"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-fil-markets/storagemarket"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/oni/lotus-soup/testkit"
+)
+
+type randomFile struct {
+	seed      int64
+	size      uint64
+	localPath string
+	rootCid   cid.Cid
+}
+
+func makeRandomFile(ctx context.Context, client api.FullNode, size uint64, seed int64) *randomFile {
+	data := make([]byte, size)
+	rand.New(rand.NewSource(seed)).Read(data)
+	f, err := ioutil.TempFile("/tmp", "oni-data")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	if _, err = f.Write(data); err != nil {
+		panic(err)
+	}
+
+	// import the data to get its root cid
+	res, err := client.ClientImport(ctx, api.FileRef{Path: f.Name()})
+	if err != nil {
+		panic(err)
+	}
+
+	// now remove the imported data; we just want the CID, but importing seems to be the easiest way to get it
+	if err = client.ClientRemoveImport(ctx, res.ImportID); err != nil {
+		panic(err)
+	}
+
+	return &randomFile{
+		seed:      seed,
+		size:      size,
+		localPath: f.Name(),
+		rootCid:   res.Root,
+	}
+}
+
+func getPieceCommitment(ctx context.Context, client api.FullNode, minerActorAddr address.Address, file *randomFile) (*api.CommPRet, error) {
+	return client.ClientCalcCommP(ctx, file.localPath, minerActorAddr)
+}
+
+func triggerMinerImport(t *testkit.TestEnvironment, ctx context.Context, file *randomFile, dealCid *cid.Cid, minerAddr address.Address) {
+	t.RecordMessage("asking miner %s to import offline data for deal %s", minerAddr, dealCid)
+	t.SyncClient.MustPublish(ctx, testkit.OfflineDealsTopic, testkit.ImportOfflineDataMsg{
+		TargetMiner: minerAddr,
+		ProposalCid: *dealCid,
+		RandSeed:    file.seed,
+		Size:        file.size,
+	})
+}
+
+func dealsOffline(t *testkit.TestEnvironment) error {
+	// Dispatch/forward non-client roles to defaults.
+	if t.Role != "client" {
+		return testkit.HandleDefaultRole(t)
+	}
+
+	t.RecordMessage("running client")
+
+	cl, err := testkit.PrepareClient(t)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	client := cl.FullApi
+
+	// select a random miner
+	minerAddr := cl.MinerAddrs[rand.Intn(len(cl.MinerAddrs))]
+	if err := client.NetConnect(ctx, minerAddr.MinerNetAddrs); err != nil {
+		return err
+	}
+
+	t.RecordMessage("selected %s as the miner", minerAddr.MinerActorAddr)
+
+	time.Sleep(2 * time.Second)
+
+	// prepare a number of concurrent data points
+	deals := t.IntParam("deals")
+	// TODO make test parameters for these:
+	fileSize := uint64(1600)
+	price := types.NewInt(1000)
+	startEpochOffset := abi.ChainEpoch(60)
+	if t.IsParamSet("deal_start_epoch") {
+		startEpochOffset = abi.ChainEpoch(t.IntParam("deal_start_epoch"))
+	}
+
+	// this to avoid failure to get block
+	time.Sleep(2 * time.Second)
+
+	t.RecordMessage("starting storage deals")
+
+	var dealCids []*cid.Cid
+
+	for i := 0; i < deals; i++ {
+		seed := time.Now().Unix() * int64(i)
+		file := makeRandomFile(ctx, client, fileSize, seed)
+
+		commP, err := getPieceCommitment(ctx, client, minerAddr.MinerActorAddr, file)
+		if err != nil {
+			t.RecordMessage("error getting piece commitment for offline deal: %s", err)
+			continue
+		}
+
+		head, err := client.ChainHead(ctx)
+		if err != nil {
+			return err
+		}
+		startEpoch := head.Height() + startEpochOffset
+
+		deal := testkit.StartOfflineDeal(ctx, minerAddr.MinerActorAddr, client, price, startEpoch, file.rootCid, commP.Root, commP.Size)
+		t.RecordMessage("started storage deal %d -> %s", i, deal)
+		dealCids = append(dealCids, deal)
+
+		triggerMinerImport(t, ctx, file, deal, minerAddr.MinerActorAddr)
+	}
+
+	pending := make(map[cid.Cid]struct{})
+	for _, d := range dealCids {
+		pending[*d] = struct{}{}
+	}
+
+	dealPollInterval := 2 * time.Second
+	for ; len(pending) > 0; time.Sleep(dealPollInterval) {
+		allDeals, err := client.ClientListDeals(ctx)
+		t.RecordMessage("got %d total deals", len(allDeals))
+		if err != nil {
+			panic(err)
+		}
+		for _, di := range allDeals {
+			if _, ok := pending[di.ProposalCid]; !ok {
+				continue
+			}
+
+			switch di.State {
+			case storagemarket.StorageDealProposalRejected:
+				t.RecordMessage("deal %s rejected: %s", di.ProposalCid, di.Message)
+				delete(pending, di.ProposalCid)
+			case storagemarket.StorageDealFailing:
+				t.RecordMessage("deal %s failed: %s", di.ProposalCid, di.Message)
+				delete(pending, di.ProposalCid)
+			case storagemarket.StorageDealError:
+				t.RecordMessage("deal %s errored %s", di.ProposalCid, di.Message)
+				delete(pending, di.ProposalCid)
+			case storagemarket.StorageDealActive:
+				t.RecordMessage("completed deal: %s", di)
+				delete(pending, di.ProposalCid)
+			}
+		}
+	}
+
+	t.SyncClient.MustSignalEntry(ctx, testkit.StateStopMining)
+	t.SyncClient.MustSignalAndWait(ctx, testkit.StateDone, t.TestInstanceCount)
+
+	time.Sleep(15 * time.Second) // wait for metrics to be emitted
+
+	return nil
+}

--- a/lotus-soup/deals_offline.go
+++ b/lotus-soup/deals_offline.go
@@ -112,12 +112,19 @@ func dealsOffline(t *testkit.TestEnvironment) error {
 
 	t.RecordMessage("starting storage deals")
 
+	rootCids := make(map[cid.Cid]struct{})
 	var dealCids []*cid.Cid
 
 	for i := 0; i < deals; i++ {
 		seed := time.Now().Unix() * int64(i)
 		file := makeRandomFile(ctx, client, fileSize, seed)
 
+		// just in case... adding this b/c I got a weird error about "already tracking identifier <cid>"
+		if _, ok := rootCids[file.rootCid]; ok {
+			continue
+		}
+		rootCids[file.rootCid] = struct{}{}
+		
 		commP, err := getPieceCommitment(ctx, client, minerAddr.MinerActorAddr, file)
 		if err != nil {
 			t.RecordMessage("error getting piece commitment for offline deal: %s", err)

--- a/lotus-soup/deals_offline.go
+++ b/lotus-soup/deals_offline.go
@@ -136,7 +136,7 @@ func dealsOffline(t *testkit.TestEnvironment) error {
 
 		triggerMinerImport(t, ctx, file, deal, minerAddr.MinerActorAddr)
 
-		if deals%100 == 0 {
+		if i%100 == 0 {
 			recordDealInfo(t, ctx, client)
 		}
 	}

--- a/lotus-soup/go.mod
+++ b/lotus-soup/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/filecoin-project/go-fil-markets v0.5.1
 	github.com/filecoin-project/go-jsonrpc v0.1.1-0.20200602181149-522144ab4e24
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
-	github.com/filecoin-project/lotus v0.4.2-0.20200724113535-7410c057c6b2
-	github.com/filecoin-project/sector-storage v0.0.0-20200723200950-ed2e57dde6df
+	github.com/filecoin-project/lotus v0.4.3-0.20200727232759-291d2fe2ded7
+	github.com/filecoin-project/sector-storage v0.0.0-20200727112136-9377cb376d25
 	github.com/filecoin-project/specs-actors v0.8.1-0.20200724015154-3c690d9b7e1d
 	github.com/filecoin-project/storage-fsm v0.0.0-20200720190000-2cfe2fe3c334
 	github.com/google/uuid v1.1.1

--- a/lotus-soup/go.sum
+++ b/lotus-soup/go.sum
@@ -233,7 +233,6 @@ github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.m
 github.com/filecoin-project/go-address v0.0.2-0.20200504173055-8b6f2fb2b3ef h1:Wi5E+P1QfHP8IF27eUiTx5vYfqQZwfPxzq3oFEq8w8U=
 github.com/filecoin-project/go-address v0.0.2-0.20200504173055-8b6f2fb2b3ef/go.mod h1:SrA+pWVoUivqKOfC+ckVYbx41hWz++HxJcrlmHNnebU=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
-github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2 h1:jamfsxfK0Q9yCMHt8MPWx7Aa/O9k2Lve8eSc6FILYGQ=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
 github.com/filecoin-project/go-amt-ipld/v2 v2.1.0 h1:t6qDiuGYYngDqaLc2ZUvdtAg4UNxPeOYaXhBWSNsVaM=
 github.com/filecoin-project/go-amt-ipld/v2 v2.1.0/go.mod h1:nfFPoGyX0CU9SkXX8EoCcSuHN1XcbN0c6KBh7yvP5fs=
@@ -241,7 +240,6 @@ github.com/filecoin-project/go-bitfield v0.0.0-20200416002808-b3ee67ec9060/go.mo
 github.com/filecoin-project/go-bitfield v0.0.1/go.mod h1:Ry9/iUlWSyjPUzlAvdnfy4Gtvrq4kWmWDztCU1yEgJY=
 github.com/filecoin-project/go-bitfield v0.0.2-0.20200518150651-562fdb554b6e/go.mod h1:Ry9/iUlWSyjPUzlAvdnfy4Gtvrq4kWmWDztCU1yEgJY=
 github.com/filecoin-project/go-bitfield v0.0.3/go.mod h1:Ry9/iUlWSyjPUzlAvdnfy4Gtvrq4kWmWDztCU1yEgJY=
-github.com/filecoin-project/go-bitfield v0.0.4-0.20200703174658-f4a5758051a1 h1:xuHlrdznafh7ul5t4xEncnA4qgpQvJZEw+mr98eqHXw=
 github.com/filecoin-project/go-bitfield v0.0.4-0.20200703174658-f4a5758051a1/go.mod h1:Ry9/iUlWSyjPUzlAvdnfy4Gtvrq4kWmWDztCU1yEgJY=
 github.com/filecoin-project/go-bitfield v0.1.0 h1:ZDAQjvXuLzbrLnwfFruQFJP7IhImmXLuO+8i2qeAczM=
 github.com/filecoin-project/go-bitfield v0.1.0/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
@@ -258,6 +256,8 @@ github.com/filecoin-project/go-fil-markets v0.5.1 h1:Y69glslNCuXnygfesCmyilTVhEE
 github.com/filecoin-project/go-fil-markets v0.5.1/go.mod h1:GKGigsFNMvKmx/+Mcn7093TdZTiCDLc7YGxQ7d6fq2s=
 github.com/filecoin-project/go-jsonrpc v0.1.1-0.20200602181149-522144ab4e24 h1:Jc7vkplmZYVuaEcSXGHDwefvZIdoyyaoGDLqSr8Svms=
 github.com/filecoin-project/go-jsonrpc v0.1.1-0.20200602181149-522144ab4e24/go.mod h1:j6zV//WXIIY5kky873Q3iIKt/ViOE8rcijovmpxrXzM=
+github.com/filecoin-project/go-multistore v0.0.1 h1:wXCd02azCxEcMNlDE9lksraQO+iIjFGNw01IZyf8GPA=
+github.com/filecoin-project/go-multistore v0.0.1/go.mod h1:z8NeSPWubEvrzi0XolhZ1NjTeW9ZDR779M+EDhf4QIQ=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:92PET+sx1Hb4W/8CgFwGuxaKbttwY+UNspYZTvXY0vs=
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6/go.mod h1:0HgYnrkeSU4lu1p+LEOeDpFsNBssa0OGGriWdA4hvaE=
 github.com/filecoin-project/go-paramfetch v0.0.1/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
@@ -271,12 +271,12 @@ github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIi
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
-github.com/filecoin-project/lotus v0.4.2-0.20200724113535-7410c057c6b2 h1:pX+EePSHTjehobovJ1r/yLZYp15xxMBUvTHBazWtAkk=
-github.com/filecoin-project/lotus v0.4.2-0.20200724113535-7410c057c6b2/go.mod h1:IQkgDgoVi+9NZEhNvYbYXW2ZCsC8fU0oB3kng1ZDdts=
+github.com/filecoin-project/lotus v0.4.3-0.20200727232759-291d2fe2ded7 h1:QlkfjjJmPrdLebB7PIhbMX21lwXcVkv/LQvIaTh6UKA=
+github.com/filecoin-project/lotus v0.4.3-0.20200727232759-291d2fe2ded7/go.mod h1:hzKwQtN5FgWzov+9l44koKb+G6xH9pzVuf1XrlJr5TA=
 github.com/filecoin-project/sector-storage v0.0.0-20200615154852-728a47ab99d6/go.mod h1:M59QnAeA/oV+Z8oHFLoNpGMv0LZ8Rll+vHVXX7GirPM=
 github.com/filecoin-project/sector-storage v0.0.0-20200712023225-1d67dcfa3c15/go.mod h1:salgVdX7qeXFo/xaiEQE29J4pPkjn71T0kt0n+VDBzo=
-github.com/filecoin-project/sector-storage v0.0.0-20200723200950-ed2e57dde6df h1:VDdWrCNUNx6qeHnGU9oAy+izuGM02it9V/5+MJyhZQw=
-github.com/filecoin-project/sector-storage v0.0.0-20200723200950-ed2e57dde6df/go.mod h1:7EE+f7jM4kCy2MKHoiiwNDQGJSb+QQzZ+y+/17ugq4w=
+github.com/filecoin-project/sector-storage v0.0.0-20200727112136-9377cb376d25 h1:sTonFkDw3KrIFIJTfIevYXyk+Mu9LbjbOHn/fWoMOMc=
+github.com/filecoin-project/sector-storage v0.0.0-20200727112136-9377cb376d25/go.mod h1:f9W29dKqNFm8Su4OddGwkAQOYMKYUR5Fk2oC/JZDjCI=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.3.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
 github.com/filecoin-project/specs-actors v0.6.0/go.mod h1:dRdy3cURykh2R8O/DKqy8olScl70rmIS7GrB4hB1IDY=
@@ -436,7 +436,6 @@ github.com/gxed/go-shellwords v1.0.3/go.mod h1:N7paucT91ByIjmVJHhvoarjoQnmsi3Jd3
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/gxed/pubsub v0.0.0-20180201040156-26ebdf44f824/go.mod h1:OiEWyHgK+CWrmOlVquHaIK1vhpUJydC9m0Je6mhaiNE=
-github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099 h1:vQqOW42RRM5LoM/1K5dK940VipLqpH8lEVGrMz+mNjU=
 github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099/go.mod h1:WVPCl0HO/0RAL5+vBH2GMxBomlxBF70MAS78+Lu1//k=
 github.com/hannahhoward/cbor-gen-for v0.0.0-20200723175505-5892b522820a h1:wfqh5oiHXvn3Rk54xy8Cwqh+HnYihGnjMNzdNb3/ld0=
 github.com/hannahhoward/cbor-gen-for v0.0.0-20200723175505-5892b522820a/go.mod h1:jvfsLIxk0fY/2BKSQ1xf2406AKA5dwMmKKv0ADcOfN8=
@@ -1418,7 +1417,6 @@ github.com/whyrusleeping/cbor-gen v0.0.0-20200414195334-429a0b5e922e/go.mod h1:X
 github.com/whyrusleeping/cbor-gen v0.0.0-20200501232601-351665a6e756/go.mod h1:W5MvapuoHRP8rz4vxjwCK1pDqF1aQcWsV5PZ+AHbqdg=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200504204219-64967432584d/go.mod h1:W5MvapuoHRP8rz4vxjwCK1pDqF1aQcWsV5PZ+AHbqdg=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200710004633-5379fc63235d/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
-github.com/whyrusleeping/cbor-gen v0.0.0-20200715143311-227fab5a2377 h1:LHFlP/ktDvOnCap7PsT87cs7Gwd0p+qv6Qm5g2ZPR+I=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200715143311-227fab5a2377/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200723182808-cb5de1c427f5 h1:dJgLhFKggti1Xd7GczL4DetAUyx68RhpCKCfV71ongg=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200723182808-cb5de1c427f5/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=

--- a/lotus-soup/init.go
+++ b/lotus-soup/init.go
@@ -39,7 +39,7 @@ func init() {
 
 	// Number of epochs between publishing the precommit and when the challenge for interactive PoRep is drawn
 	// used to ensure it is not predictable by miner.
-	miner.PreCommitChallengeDelay = abi.ChainEpoch(10)
+	//miner.PreCommitChallengeDelay = abi.ChainEpoch(10)
 
 	power.ConsensusMinerMinPower = big.NewInt(2048)
 	miner.SupportedProofTypes = map[abi.RegisteredSealProof]struct{}{

--- a/lotus-soup/main.go
+++ b/lotus-soup/main.go
@@ -14,6 +14,7 @@ var cases = map[string]interface{}{
 	"deals-stress":                  testkit.WrapTestEnvironment(dealsStress),
 	"drand-halting":                 testkit.WrapTestEnvironment(dealsE2E),
 	"paych-stress":                  testkit.WrapTestEnvironment(paych.Stress),
+	"deals-offline":                 testkit.WrapTestEnvironment(dealsOffline),
 }
 
 func main() {

--- a/lotus-soup/manifest.toml
+++ b/lotus-soup/manifest.toml
@@ -122,6 +122,37 @@ instances = { min = 1, max = 100, default = 5 }
   deals = { type = "int", default = 1 }
   deal_mode = { type = "enum", default = "serial", options = ["serial", "concurrent"] }
 
+[[testcases]]
+name = "deals-offline"
+instances = { min = 1, max = 100, default = 5 }
+
+  [testcases.params]
+  clients = { type = "int", default = 1 }
+  miners = { type = "int", default = 1 }
+  balance = { type = "float", default = 1 }
+  sectors = { type = "int", default = 1 }
+  role = { type = "string" }
+
+  genesis_timestamp_offset = { type = "int", default = 0 }
+
+  random_beacon_type = { type = "enum", default = "mock", options = ["mock", "local-drand", "external-drand"] }
+
+  # Params relevant to drand nodes. drand nodes should have role="drand", and must all be
+  # in the same composition group. There must be at least threshold drand nodes.
+  # To get lotus nodes to actually use the drand nodes, you must set random_beacon_type="local-drand"
+  # for the lotus node groups.
+  drand_period = { type = "duration", default="10s" }
+  drand_threshold = { type = "int", default = 2 }
+  drand_gossip_relay = { type = "bool", default = true }
+
+  # Params relevant to pubsub tracing
+  enable_pubsub_tracer = { type = "bool", default = false }
+
+  # Mining Mode: synchronized -vs- natural time
+  mining_mode = { type = "enum", default = "synchronized", options = ["synchronized", "natural"] }
+
+  deals = { type = "int", default = 1 }
+
 
 [[testcases]]
 name = "paych-stress"

--- a/lotus-soup/rfwp/chain_state.go
+++ b/lotus-soup/rfwp/chain_state.go
@@ -560,7 +560,7 @@ func sectorsList(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr addres
 	i := SectorInfo{Sectors: list, SectorStates: make(map[abi.SectorNumber]api.SectorInfo, len(list))}
 
 	for _, s := range list {
-		st, err := m.MinerApi.SectorsStatus(ctx, s)
+		st, err := m.MinerApi.SectorsStatus(ctx, s, true)
 		if err != nil {
 			fmt.Fprintf(w, "%d:\tError: %s\n", s, err)
 			continue
@@ -756,7 +756,7 @@ func info(t *testkit.TestEnvironment, m *testkit.LotusMiner, maddr address.Addre
 		"Total": len(sectors),
 	}
 	for _, s := range sectors {
-		st, err := m.MinerApi.SectorsStatus(ctx, s)
+		st, err := m.MinerApi.SectorsStatus(ctx, s, false)
 		if err != nil {
 			return nil, err
 		}

--- a/lotus-soup/testkit/deals.go
+++ b/lotus-soup/testkit/deals.go
@@ -68,3 +68,29 @@ func WaitDealSealed(t *TestEnvironment, ctx context.Context, client api.FullNode
 		t.RecordMessage("deal state: %s", storagemarket.DealStates[di.State])
 	}
 }
+
+func StartOfflineDeal(ctx context.Context, minerActorAddr address.Address, client api.FullNode, price types.BigInt, startEpoch abi.ChainEpoch, rootCid cid.Cid, pieceCid cid.Cid, commPSize abi.UnpaddedPieceSize) *cid.Cid {
+	addr, err := client.WalletDefaultAddress(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	deal, err := client.ClientStartDeal(ctx, &api.StartDealParams{
+		Data: &storagemarket.DataRef{
+			TransferType: storagemarket.TTManual,
+			Root:         rootCid,
+			PieceCid:     &pieceCid,
+			PieceSize:    commPSize,
+		},
+		Wallet:            addr,
+		Miner:             minerActorAddr,
+		EpochPrice:        price,
+		DealStartEpoch:    startEpoch,
+		MinBlocksDuration: 10000,
+		FastRetrieval:     false,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return deal
+}

--- a/lotus-soup/testkit/sync.go
+++ b/lotus-soup/testkit/sync.go
@@ -4,6 +4,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/genesis"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
+	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/testground/sdk-go/sync"
 )
@@ -17,6 +18,7 @@ var (
 	SlashedMinerTopic = sync.NewTopic("slashed_miner", &SlashedMinerMsg{})
 	PubsubTracerTopic = sync.NewTopic("pubsub_tracer", &PubsubTracerMsg{})
 	DrandConfigTopic  = sync.NewTopic("drand_config", &DrandRuntimeInfo{})
+	OfflineDealsTopic = sync.NewTopic("offline_deals", &ImportOfflineDataMsg{})
 )
 
 var (
@@ -65,4 +67,13 @@ type PubsubTracerMsg struct {
 type DrandRuntimeInfo struct {
 	Config          dtypes.DrandConfig
 	GossipBootstrap dtypes.DrandBootstrap
+}
+
+// Tell a miner to import data for an offline deal. Each side generates the data locally
+// using the given RandSeed so we don't have to ship a bunch of data around.
+type ImportOfflineDataMsg struct {
+	TargetMiner address.Address
+	ProposalCid cid.Cid
+	RandSeed    int64
+	Size        uint64
 }


### PR DESCRIPTION
This adds a `deals-offline` test case that tries to figure out the client-side scaling limits for proposing and tracking deals (closes #160).

The basic flow is:

- client picks a random seed and generates a file using it
- client imports the file into their local store to get the root CID, then removes it from the local store (probably not necessary to remove, but seems closer to the real scenario)
- client calculates the piece commitment (`commP`) and sends the rand seed, file size and commP on the sync service
- miner sees an `ImportOfflineDataMsg` on the sync service and generates the file on their end and imports it.
- every 100 deals, the client calls `ClientListDeals` and dumps the deal states to `t.RecordMessage`

The miner side of things is currently pretty broken; lots of gas limit errors like this:

```
Jul 28 17:07:19.458837  INFO    61.9329s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.457Z WARN    vm      vm/runtime.go:144       VM.Call failure: not enough gas: used=14966134, available=14966134 (RetCode=7): {"req_id": "04bdfdc3"}
Jul 28 17:07:19.458928  INFO    61.9331s      ERROR << miners[000] (0d9cc7) >>     github.com/filecoin-project/lotus/chain/vm.(*Runtime).chargeGasInternal      {"req_id": "04bdfdc3"}
Jul 28 17:07:19.458961  INFO    61.9331s      ERROR << miners[000] (0d9cc7) >>         /go/pkg/mod/github.com/filecoin-project/lotus@v0.4.3-0.20200727232759-291d2fe2ded7/chain/vm/runtime.go:555       {"req_id": "04bdfdc3"}
Jul 28 17:07:19.458976  INFO    61.9331s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.457Z WARN    vm      vm/runtime.go:367       vmctx send failed: to: t04, method: 4: ret: [], err: not enough gas: used=14966134, available=14966134 (RetCode=7)      {"req_id": "04bdfdc3"}
Jul 28 17:07:19.458990  INFO    61.9331s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.457Z WARN    vm      vm/runtime.go:315       Abortf: failed to enroll cron event     {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459038  INFO    61.9332s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.457Z WARN    vm      vm/runtime.go:144       VM.Call failure: failed to enroll cron event (RetCode=7):       {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459085  INFO    61.9332s      ERROR << miners[000] (0d9cc7) >>     github.com/filecoin-project/specs-actors/actors/builtin.RequireSuccess       {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459103  INFO    61.9332s      ERROR << miners[000] (0d9cc7) >>         /go/pkg/mod/github.com/filecoin-project/specs-actors@v0.8.1-0.20200724015154-3c690d9b7e1d/actors/builtin/shared.go:24    {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459124  INFO    61.9332s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.457Z WARN    vm      vm/vm.go:419    Send actor error        {"from": "t3sdzfoz2rkohcoixjaxgnxmqeupyrtqb44f6bb27zkowwhncn4biawzkpasppy3pl52opzritaamjn2ol5aca", "to": "t01000", "nonce": 80, "method": "6", "height": "29", "error": "failed to enroll cron event (RetCode=7):\n    github.com/filecoin-project/specs-actors/actors/builtin.RequireSuccess\n        /go/pkg/mod/github.com/filecoin-project/specs-actors@v0.8.1-0.20200724015154-3c690d9b7e1d/actors/builtin/shared.go:24"}      {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459313  INFO    61.9334s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.458Z WARN    vm      vm/runtime.go:144       VM.Call failure: not enough gas: used=14966134, available=14966134 (RetCode=7): {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459382  INFO    61.9335s      ERROR << miners[000] (0d9cc7) >>     github.com/filecoin-project/lotus/chain/vm.(*Runtime).chargeGasInternal      {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459441  INFO    61.9336s      ERROR << miners[000] (0d9cc7) >>         /go/pkg/mod/github.com/filecoin-project/lotus@v0.4.3-0.20200727232759-291d2fe2ded7/chain/vm/runtime.go:555       {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459505  INFO    61.9336s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.458Z WARN    vm      vm/runtime.go:367       vmctx send failed: to: t04, method: 4: ret: [], err: not enough gas: used=14966134, available=14966134 (RetCode=7)      {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459540  INFO    61.9337s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.458Z WARN    vm      vm/runtime.go:315       Abortf: failed to enroll cron event     {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459573  INFO    61.9337s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.458Z WARN    vm      vm/runtime.go:144       VM.Call failure: failed to enroll cron event (RetCode=7):       {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459592  INFO    61.9337s      ERROR << miners[000] (0d9cc7) >>     github.com/filecoin-project/specs-actors/actors/builtin.RequireSuccess       {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459656  INFO    61.9338s      ERROR << miners[000] (0d9cc7) >>         /go/pkg/mod/github.com/filecoin-project/specs-actors@v0.8.1-0.20200724015154-3c690d9b7e1d/actors/builtin/shared.go:24    {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459680  INFO    61.9338s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.458Z WARN    vm      vm/vm.go:419    Send actor error        {"from": "t3sdzfoz2rkohcoixjaxgnxmqeupyrtqb44f6bb27zkowwhncn4biawzkpasppy3pl52opzritaamjn2ol5aca", "to": "t01000", "nonce": 81, "method": "6", "height": "29", "error": "failed to enroll cron event (RetCode=7):\n    github.com/filecoin-project/specs-actors/actors/builtin.RequireSuccess\n        /go/pkg/mod/github.com/filecoin-project/specs-actors@v0.8.1-0.20200724015154-3c690d9b7e1d/actors/builtin/shared.go:24"}      {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459737  INFO    61.9339s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.459Z WARN    vm      vm/runtime.go:144       VM.Call failure: not enough gas: used=14968534, available=14968534 (RetCode=7): {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459797  INFO    61.9339s      ERROR << miners[000] (0d9cc7) >>     github.com/filecoin-project/lotus/chain/vm.(*Runtime).chargeGasInternal      {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459832  INFO    61.9340s      ERROR << miners[000] (0d9cc7) >>         /go/pkg/mod/github.com/filecoin-project/lotus@v0.4.3-0.20200727232759-291d2fe2ded7/chain/vm/runtime.go:555       {"req_id": "04bdfdc3"}
Jul 28 17:07:19.459877  INFO    61.9340s      ERROR << miners[000] (0d9cc7) >> 2020-07-28T17:07:19.459Z WARN    vm      vm/runtime.go:367       vmctx send failed: to: t04, method: 4: ret: [], err: not enough gas: used=14968534, available=14968534 (RetCode=7)      {"req_id": "04bdfdc3"}
```


There are also some errors about missing deals when sealing kicks in:

```
Jul 28 19:30:33.063336  INFO    129.8215s    MESSAGE << clients[000] (7113e3) >> deal states:
StorageDealSealing  120
        {"req_id": "9deca62e"}
Jul 28 19:30:34.018913  INFO    130.7775s      ERROR << miners[000] (f9f87c) >> 2020-07-28T19:30:34.018Z        WARN    chain   chain/sync.go:647       [INSECURE-POST-VALIDATION] if you see this outside of a test, it is a severe bug!       {"req_id": "9deca62e"}
Jul 28 19:30:34.726583  INFO    131.4851s      ERROR << miners[000] (f9f87c) >> 2020-07-28T19:30:34.725Z        WARN    vm      vm/runtime.go:315       Abortf: failed to validate dealProposals for activation: dealId 117 not found   {"req_id": "9deca62e"}
Jul 28 19:30:34.726657  INFO    131.4852s      ERROR << miners[000] (f9f87c) >> 2020-07-28T19:30:34.726Z        WARN    vm      vm/runtime.go:144       VM.Call failure: failed to validate dealProposals for activation: dealId 117 not found (RetCode=20):    {"req_id": "9deca62e"}
Jul 28 19:30:34.726677  INFO    131.4853s      ERROR << miners[000] (f9f87c) >>     github.com/filecoin-project/specs-actors/actors/builtin.RequireNoErr        {"req_id": "9deca62e"}
Jul 28 19:30:34.726691  INFO    131.4853s      ERROR << miners[000] (f9f87c) >>         /go/pkg/mod/github.com/filecoin-project/specs-actors@v0.8.1-0.20200724015154-3c690d9b7e1d/actors/builtin/shared.go:34   {"req_id": "9deca62e"}
Jul 28 19:30:34.726705  INFO    131.4853s      ERROR << miners[000] (f9f87c) >> 2020-07-28T19:30:34.726Z        WARN    vm      vm/runtime.go:367       vmctx send failed: to: t05, method: 5: ret: [], err: failed to validate dealProposals for activation: dealId 117 not found (RetCode=20) {"req_id": "9deca62e"}
Jul 28 19:30:34.726723  INFO    131.4853s      ERROR << miners[000] (f9f87c) >> 2020-07-28T19:30:34.726Z        WARN    vm      vm/runtime.go:315       Abortf: failed to verify deals and get deal weight      {"req_id": "9deca62e"}
Jul 28 19:30:34.726738  INFO    131.4853s      ERROR << miners[000] (f9f87c) >> 2020-07-28T19:30:34.726Z        WARN    vm      vm/runtime.go:144       VM.Call failure: failed to verify deals and get deal weight (RetCode=20):       {"req_id": "9deca62e"}
Jul 28 19:30:34.726751  INFO    131.4853s      ERROR << miners[000] (f9f87c) >>     github.com/filecoin-project/specs-actors/actors/builtin.RequireSuccess      {"req_id": "9deca62e"}
Jul 28 19:30:34.726764  INFO    131.4853s      ERROR << miners[000] (f9f87c) >>         /go/pkg/mod/github.com/filecoin-project/specs-actors@v0.8.1-0.20200724015154-3c690d9b7e1d/actors/builtin/shared.go:24   {"req_id": "9deca62e"}
Jul 28 19:30:34.726778  INFO    131.4854s      ERROR << miners[000] (f9f87c) >> 2020-07-28T19:30:34.726Z        WARN    vm      vm/vm.go:419    Send actor error        {"from": "t3ri3mdrcma3abddkzaio24y5biubuvuze26och5tvw7ogpuzc2iakck2wx6x4j2efmwsy7lqlr43ckjrvb5na", "to": "t01000", "nonce": 403, "method": "6", "height": "64", "error": "failed to verify deals and get deal weight (RetCode=20):\n    github.com/filecoin-project/specs-actors/actors/builtin.RequireSuccess\n        /go/pkg/mod/github.com/filecoin-project/specs-actors@v0.8.1-0.20200724015154-3c690d9b7e1d/actors/builtin/shared.go:24"} {"req_id": "9deca62e"}
Jul 28 19:30:34.726793  INFO    131.4854s      ERROR << miners[000] (f9f87c) >> 2020-07-28T19:30:34.726Z        WARN    vm      vm/runtime.go:315       Abortf: failed to validate dealProposals for activation: dealId 95 not found    {"req_id": "9deca62e"}
Jul 28 19:30:34.726808  INFO    131.4854s      ERROR << miners[000] (f9f87c) >> 2020-07-28T19:30:34.726Z        WARN    vm      vm/runtime.go:144       VM.Call failure: failed to validate dealProposals for activation: dealId 95 not found (RetCode=20):     {"req_id": "9deca62e"}
```

However the errors don't seem to immediately fail any deals and apparently the gas issue is affecting real deployments as well.

On the client side, all the proposed deals are making into the chain and are returned by `ClientListDeals`, so I _think_ that this test is still valid for finding the client limits even if the miner is a bit borked.

Results so far, running on a k8s cluster with c5.2xlarge workers (8 CPUs, 16GB ram) and a `testground` daemon hacked to have longer timeouts:

- with 2GB RAM allocated to client, the client gets `OOMKilled` after ~10k deals
- bumping up to 4GB RAM for the client gets us to ~63k deals before both client and miner got OOMKilled (miner was running with 8GB). Test died after roughly 90 minutes.
- with both miner and client at 12 GB RAM, test ran for 3.5 hours and client got to 84k deals

cc @ribasushi @jnthnvctr 


btw, @nonsense we may not want to merge this to master yet; I commented out the change to the pre-commit delay in `init.go` to be closer to the production scenario, so it may mess with the window post tests. I'm not sure it actually makes a difference for this test though, so we can probably put it back.