### PR TITLE
parse multiple test cases per file /2

### DIFF
--- a/tvx/extract_msg.go
+++ b/tvx/extract_msg.go
@@ -195,7 +195,6 @@ func runExtractMsg(c *cli.Context) error {
 	defer file.Close()
 
 	enc := json.NewEncoder(file)
-	enc.SetIndent("", "  ")
 	if err := enc.Encode(&vector); err != nil {
 		return err
 	}


### PR DESCRIPTION
In https://github.com/filecoin-project/oni/pull/181 , I am generating multiple test vectors per file, that are new line delimited.

This is adding support to actually process all of them, and not just one per file.