### PR TITLE
refactor: add default TestVector to TestDriver

### DIFF
--- a/tvx/chain/address.go
+++ b/tvx/chain/address.go
@@ -44,7 +44,7 @@ func MustNewActorAddr(data string) addr.Address {
 	return address
 }
 
-func MustIdFromAddress(a addr.Address) uint64 {
+func MustIDFromAddress(a addr.Address) uint64 {
 	if a.Protocol() != addr.ID {
 		panic("must be ID protocol address")
 	}

--- a/tvx/drivers/state_driver.go
+++ b/tvx/drivers/state_driver.go
@@ -120,7 +120,7 @@ func (d *StateDriver) newMinerAccountActor(sealProofType abi_spec.RegisteredSeal
 	// creat a miner, owner, and its worker
 	minerOwnerPk, minerOwnerID := d.NewAccountActor(address.SECP256K1, big_spec.NewInt(1_000_000_000))
 	minerWorkerPk, minerWorkerID := d.NewAccountActor(address.BLS, big_spec.Zero())
-	expectedMinerActorIDAddress := chain.MustNewIDAddr(chain.MustIdFromAddress(minerWorkerID) + 1)
+	expectedMinerActorIDAddress := chain.MustNewIDAddr(chain.MustIDFromAddress(minerWorkerID) + 1)
 	minerActorAddrs := computeInitActorExecReturn(minerWorkerPk, 0, 1, expectedMinerActorIDAddress)
 
 	d.minerInfo = &MinerInfo{

--- a/tvx/drivers/test_driver.go
+++ b/tvx/drivers/test_driver.go
@@ -44,6 +44,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/oni/tvx/chain"
 	vtypes "github.com/filecoin-project/oni/tvx/chain/types"
+	"github.com/filecoin-project/oni/tvx/schema"
 )
 
 var (
@@ -235,6 +236,25 @@ func NewTestDriver() *TestDriver {
 	checkRet := true
 	config := NewConfig(checkExit, checkRet)
 
+	vector := schema.TestVector{
+		Class:    schema.ClassMessage,
+		Selector: "",
+		Meta: &schema.Metadata{
+			ID:      "TK",
+			Version: "TK",
+			Gen: schema.GenerationData{
+				Source:  "TK",
+				Version: "TK",
+			},
+		},
+		Pre: &schema.Preconditions{
+			StateTree: &schema.StateTree{},
+		},
+		Post: &schema.Postconditions{
+			StateTree: &schema.StateTree{},
+		},
+	}
+
 	return &TestDriver{
 		StateDriver: sd,
 
@@ -244,6 +264,7 @@ func NewTestDriver() *TestDriver {
 		SysCalls:        syscalls,
 
 		applier: applier,
+		Vector:  &vector,
 	}
 }
 
@@ -265,6 +286,9 @@ type TestDriver struct {
 	Config *Config
 
 	SysCalls *ChainValidationSysCalls
+	// Vector is the test vector that is used when methods are called on the
+	// driver that apply messages.
+	Vector *schema.TestVector
 }
 
 //

--- a/tvx/examine.go
+++ b/tvx/examine.go
@@ -14,6 +14,7 @@ import (
 	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 
+	"github.com/filecoin-project/oni/tvx/schema"
 	"github.com/filecoin-project/oni/tvx/state"
 )
 
@@ -62,7 +63,7 @@ func runExamineCmd(_ *cli.Context) error {
 		return err
 	}
 
-	var tv TestVector
+	var tv schema.TestVector
 	if err := json.NewDecoder(file).Decode(&tv); err != nil {
 		return err
 	}

--- a/tvx/exec_lotus.go
+++ b/tvx/exec_lotus.go
@@ -15,6 +15,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/filecoin-project/oni/tvx/lotus"
+	"github.com/filecoin-project/oni/tvx/schema"
 )
 
 var execLotusFlags struct {
@@ -44,7 +45,7 @@ func runExecLotus(_ *cli.Context) error {
 
 		var (
 			dec = json.NewDecoder(file)
-			tv  TestVector
+			tv  schema.TestVector
 		)
 
 		if err = dec.Decode(&tv); err != nil {
@@ -55,7 +56,7 @@ func runExecLotus(_ *cli.Context) error {
 	default:
 		dec := json.NewDecoder(os.Stdin)
 		for {
-			var tv TestVector
+			var tv schema.TestVector
 
 			err := dec.Decode(&tv)
 			if err == io.EOF {
@@ -73,7 +74,7 @@ func runExecLotus(_ *cli.Context) error {
 	}
 }
 
-func executeTestVector(tv TestVector) error {
+func executeTestVector(tv schema.TestVector) error {
 	fmt.Println("executing test vector")
 	switch tv.Class {
 	case "message":

--- a/tvx/extract_msg.go
+++ b/tvx/extract_msg.go
@@ -14,6 +14,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/filecoin-project/oni/tvx/lotus"
+	"github.com/filecoin-project/oni/tvx/schema"
 	"github.com/filecoin-project/oni/tvx/state"
 )
 
@@ -178,27 +179,27 @@ func runExtractMsg(c *cli.Context) error {
 	}
 
 	// Write out the test vector.
-	vector := TestVector{
-		Class:    ClassMessage,
+	vector := schema.TestVector{
+		Class:    schema.ClassMessage,
 		Selector: "",
-		Meta: &Metadata{
+		Meta: &schema.Metadata{
 			ID:      "TK",
 			Version: "TK",
-			Gen: GenerationData{
+			Gen: schema.GenerationData{
 				Source:  "TK",
 				Version: version.String(),
 			},
 		},
 		CAR: out.Bytes(),
-		Pre: &Preconditions{
+		Pre: &schema.Preconditions{
 			Epoch: execTs.Height(),
-			StateTree: &StateTree{
+			StateTree: &schema.StateTree{
 				RootCID: preroot,
 			},
 		},
-		ApplyMessages: []Message{{Bytes: msgBytes}},
-		Post: &Postconditions{
-			StateTree: &StateTree{
+		ApplyMessages: []schema.Message{{Bytes: msgBytes}},
+		Post: &schema.Postconditions{
+			StateTree: &schema.StateTree{
 				RootCID: postroot,
 			},
 		},

--- a/tvx/schema/schema.go
+++ b/tvx/schema/schema.go
@@ -1,4 +1,4 @@
-package main
+package schema
 
 import (
 	"encoding/hex"

--- a/tvx/suite_messages_create_actor.go
+++ b/tvx/suite_messages_create_actor.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/filecoin-project/oni/tvx/chain"
 	"github.com/filecoin-project/oni/tvx/drivers"
+	"github.com/filecoin-project/oni/tvx/schema"
 )
 
 var suiteMessagesCmd = &cli.Command{
@@ -99,7 +100,7 @@ func MessageTest_AccountActorCreation() error {
 			if err != nil {
 				return err
 			}
-			td.Vector.ApplyMessages = []Message{{Bytes: b}}
+			td.Vector.ApplyMessages = []schema.Message{{Bytes: b}}
 			result := td.ApplyFailure(
 				msg,
 				tc.expExitCode,
@@ -162,7 +163,7 @@ func MessageTest_InitActorSequentialIDAddressCreate() error {
 	if err != nil {
 		return err
 	}
-	td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: b1})
+	td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: b1})
 
 	msg2 := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(1))
 	td.ApplyExpect(
@@ -174,7 +175,7 @@ func MessageTest_InitActorSequentialIDAddressCreate() error {
 	if err != nil {
 		return err
 	}
-	td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: b2})
+	td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: b2})
 
 	postroot := td.GetStateRoot()
 

--- a/tvx/suite_messages_create_actor.go
+++ b/tvx/suite_messages_create_actor.go
@@ -20,7 +20,7 @@ import (
 
 var suiteMessagesCmd = &cli.Command{
 	Name:        "suite-messages",
-	Description: "",
+	Description: "generate test vectors from the messages test suite adapted from github.com/filecoin-project/chain-validation",
 	Action:      suiteMessages,
 }
 

--- a/tvx/suite_messages_create_actor.go
+++ b/tvx/suite_messages_create_actor.go
@@ -90,8 +90,6 @@ func MessageTest_AccountActorCreation() error {
 		err := func() error {
 			td := drivers.NewTestDriver()
 
-			v := newEmptyMessageVector()
-
 			existingAccountAddr, _ := td.NewAccountActor(tc.existingActorType, tc.existingActorBal)
 
 			preroot := td.GetStateRoot()
@@ -101,7 +99,7 @@ func MessageTest_AccountActorCreation() error {
 			if err != nil {
 				return err
 			}
-			v.ApplyMessages = []Message{{Bytes: b}}
+			td.Vector.ApplyMessages = []Message{{Bytes: b}}
 			result := td.ApplyFailure(
 				msg,
 				tc.expExitCode,
@@ -115,13 +113,13 @@ func MessageTest_AccountActorCreation() error {
 
 			postroot := td.GetStateRoot()
 
-			v.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-			v.Pre.StateTree.RootCID = preroot
-			v.Post.StateTree.RootCID = postroot
+			td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+			td.Vector.Pre.StateTree.RootCID = preroot
+			td.Vector.Post.StateTree.RootCID = postroot
 
 			// encode and output
 			enc := json.NewEncoder(os.Stdout)
-			if err := enc.Encode(&v); err != nil {
+			if err := enc.Encode(&td.Vector); err != nil {
 				return err
 			}
 
@@ -139,8 +137,6 @@ func MessageTest_AccountActorCreation() error {
 func MessageTest_InitActorSequentialIDAddressCreate() error {
 	td := drivers.NewTestDriver()
 
-	v := newEmptyMessageVector()
-
 	var initialBal = abi_spec.NewTokenAmount(200_000_000_000)
 	var toSend = abi_spec.NewTokenAmount(10_000)
 
@@ -148,8 +144,8 @@ func MessageTest_InitActorSequentialIDAddressCreate() error {
 
 	receiver, receiverID := td.NewAccountActor(drivers.SECP, initialBal)
 
-	firstPaychAddr := chain.MustNewIDAddr(chain.MustIdFromAddress(receiverID) + 1)
-	secondPaychAddr := chain.MustNewIDAddr(chain.MustIdFromAddress(receiverID) + 2)
+	firstPaychAddr := chain.MustNewIDAddr(chain.MustIDFromAddress(receiverID) + 1)
+	secondPaychAddr := chain.MustNewIDAddr(chain.MustIDFromAddress(receiverID) + 2)
 
 	firstInitRet := td.ComputeInitActorExecReturn(sender, 0, 0, firstPaychAddr)
 	secondInitRet := td.ComputeInitActorExecReturn(sender, 1, 0, secondPaychAddr)
@@ -166,7 +162,7 @@ func MessageTest_InitActorSequentialIDAddressCreate() error {
 	if err != nil {
 		return err
 	}
-	v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: b1})
+	td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: b1})
 
 	msg2 := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(1))
 	td.ApplyExpect(
@@ -178,40 +174,19 @@ func MessageTest_InitActorSequentialIDAddressCreate() error {
 	if err != nil {
 		return err
 	}
-	v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: b2})
+	td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: b2})
 
 	postroot := td.GetStateRoot()
 
-	v.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-	v.Pre.StateTree.RootCID = preroot
-	v.Post.StateTree.RootCID = postroot
+	td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+	td.Vector.Pre.StateTree.RootCID = preroot
+	td.Vector.Post.StateTree.RootCID = postroot
 
 	// encode and output
 	enc := json.NewEncoder(os.Stdout)
-	if err := enc.Encode(&v); err != nil {
+	if err := enc.Encode(&td.Vector); err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func newEmptyMessageVector() TestVector {
-	return TestVector{
-		Class:    ClassMessage,
-		Selector: "",
-		Meta: &Metadata{
-			ID:      "TK",
-			Version: "TK",
-			Gen: GenerationData{
-				Source:  "TK",
-				Version: "TK",
-			},
-		},
-		Pre: &Preconditions{
-			StateTree: &StateTree{},
-		},
-		Post: &Postconditions{
-			StateTree: &StateTree{},
-		},
-	}
 }

--- a/tvx/suite_messages_message_application.go
+++ b/tvx/suite_messages_message_application.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/filecoin-project/oni/tvx/chain"
 	"github.com/filecoin-project/oni/tvx/drivers"
+	"github.com/filecoin-project/oni/tvx/schema"
 )
 
 func MessageTest_MessageApplicationEdgecases() error {
@@ -26,7 +27,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(1), chain.GasLimit(8))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages,  Message{Bytes: chain.MustSerialize(msg))
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		td.ApplyFailure(
 			msg,
@@ -57,7 +58,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		preroot := td.GetStateRoot()
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(10), chain.GasLimit(1))
-		v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// Expect Message application to fail due to lack of gas
 		td.ApplyFailure(
@@ -66,7 +67,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		unknown := chain.MustNewIDAddr(10000000)
 		msg = td.MessageProducer.Transfer(unknown, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(10), chain.GasLimit(1))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// Expect Message application to fail due to lack of gas when sender is unknown
 		td.ApplyFailure(
@@ -105,7 +106,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		newAccountA := chain.MustNewSECP256K1Addr("1")
 
 		msg := td.MessageProducer.Transfer(alice, newAccountA, chain.Value(transferAmnt), chain.Nonce(aliceNonceF()))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// get the "true" gas cost of applying the message
 		result := td.ApplyOk(msg)
@@ -116,7 +117,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		newAccountB := chain.MustNewSECP256K1Addr("2")
 		for tryGas := trueGas - gasStep; tryGas > 0; tryGas -= gasStep {
 			msg := td.MessageProducer.Transfer(alice, newAccountB, chain.Value(transferAmnt), chain.Nonce(aliceNonceF()), chain.GasPrice(1), chain.GasLimit(tryGas))
-			td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+			td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 			td.ApplyFailure(
 				msg,
@@ -150,7 +151,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(1))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// Expect Message application to fail due to callseqnum being invalid: 1 instead of 0
 		td.ApplyFailure(
@@ -159,7 +160,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		unknown := chain.MustNewIDAddr(10000000)
 		msg = td.MessageProducer.Transfer(unknown, alice, chain.Value(transferAmnt), chain.Nonce(1))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// Expect message application to fail due to unknow actor when call seq num is also incorrect
 		td.ApplyFailure(
@@ -210,7 +211,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(0))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		td.ApplyExpect(
 			msg,
@@ -231,7 +232,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 				Signature:       pcSig, // construct with invalid signature
 			},
 		}, chain.Nonce(1), chain.Value(big_spec.Zero()))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// message application fails due to invalid argument (signature).
 		td.ApplyFailure(
@@ -265,7 +266,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		msg := td.MessageProducer.MarketComputeDataCommitment(alice, alice, nil, chain.Nonce(0))
 
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// message application fails because ComputeDataCommitment isn't defined
 		// on the recipient actor
@@ -302,7 +303,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		unknownA := chain.MustNewIDAddr(10000000)
 		msg := td.MessageProducer.Transfer(alice, unknownA, chain.Value(transferAmnt), chain.Nonce(0))
 
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		td.ApplyFailure(
 			msg,
@@ -311,7 +312,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		// Sending a message to non-existing actor address must produce an error.
 		unknownB := chain.MustNewActorAddr("1234")
 		msg = td.MessageProducer.Transfer(alice, unknownB, chain.Value(transferAmnt), chain.Nonce(1))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		td.ApplyFailure(
 			msg,

--- a/tvx/suite_messages_message_application.go
+++ b/tvx/suite_messages_message_application.go
@@ -21,13 +21,12 @@ func MessageTest_MessageApplicationEdgecases() error {
 	err := func(testname string) error {
 		td := drivers.NewTestDriver()
 
-		v := newEmptyMessageVector()
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(1), chain.GasLimit(8))
-		v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages,  Message{Bytes: chain.MustSerialize(msg))
 
 		td.ApplyFailure(
 			msg,
@@ -35,13 +34,13 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		postroot := td.GetStateRoot()
 
-		v.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		v.Pre.StateTree.RootCID = preroot
-		v.Post.StateTree.RootCID = postroot
+		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+		td.Vector.Pre.StateTree.RootCID = preroot
+		td.Vector.Post.StateTree.RootCID = postroot
 
 		// encode and output
 		enc := json.NewEncoder(os.Stdout)
-		if err := enc.Encode(&v); err != nil {
+		if err := enc.Encode(&td.Vector); err != nil {
 			return err
 		}
 
@@ -54,7 +53,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 	err = func(testname string) error {
 		td := drivers.NewTestDriver()
 
-		v := newEmptyMessageVector()
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 
 		preroot := td.GetStateRoot()
@@ -68,7 +66,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		unknown := chain.MustNewIDAddr(10000000)
 		msg = td.MessageProducer.Transfer(unknown, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(10), chain.GasLimit(1))
-		v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
 
 		// Expect Message application to fail due to lack of gas when sender is unknown
 		td.ApplyFailure(
@@ -77,13 +75,13 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		postroot := td.GetStateRoot()
 
-		v.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		v.Pre.StateTree.RootCID = preroot
-		v.Post.StateTree.RootCID = postroot
+		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+		td.Vector.Pre.StateTree.RootCID = preroot
+		td.Vector.Post.StateTree.RootCID = postroot
 
 		// encode and output
 		enc := json.NewEncoder(os.Stdout)
-		if err := enc.Encode(&v); err != nil {
+		if err := enc.Encode(&td.Vector); err != nil {
 			return err
 		}
 
@@ -96,8 +94,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 	err = func(testname string) error {
 		td := drivers.NewTestDriver()
 
-		v := newEmptyMessageVector()
-
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 		preroot := td.GetStateRoot()
 
@@ -109,7 +105,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		newAccountA := chain.MustNewSECP256K1Addr("1")
 
 		msg := td.MessageProducer.Transfer(alice, newAccountA, chain.Value(transferAmnt), chain.Nonce(aliceNonceF()))
-		v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
 
 		// get the "true" gas cost of applying the message
 		result := td.ApplyOk(msg)
@@ -120,7 +116,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		newAccountB := chain.MustNewSECP256K1Addr("2")
 		for tryGas := trueGas - gasStep; tryGas > 0; tryGas -= gasStep {
 			msg := td.MessageProducer.Transfer(alice, newAccountB, chain.Value(transferAmnt), chain.Nonce(aliceNonceF()), chain.GasPrice(1), chain.GasLimit(tryGas))
-			v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+			td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
 
 			td.ApplyFailure(
 				msg,
@@ -130,13 +126,13 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		postroot := td.GetStateRoot()
 
-		v.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		v.Pre.StateTree.RootCID = preroot
-		v.Post.StateTree.RootCID = postroot
+		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+		td.Vector.Pre.StateTree.RootCID = preroot
+		td.Vector.Post.StateTree.RootCID = postroot
 
 		// encode and output
 		enc := json.NewEncoder(os.Stdout)
-		if err := enc.Encode(&v); err != nil {
+		if err := enc.Encode(&td.Vector); err != nil {
 			return err
 		}
 
@@ -149,14 +145,12 @@ func MessageTest_MessageApplicationEdgecases() error {
 	err = func(testname string) error {
 		td := drivers.NewTestDriver()
 
-		v := newEmptyMessageVector()
-
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(1))
-		v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
 
 		// Expect Message application to fail due to callseqnum being invalid: 1 instead of 0
 		td.ApplyFailure(
@@ -165,7 +159,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		unknown := chain.MustNewIDAddr(10000000)
 		msg = td.MessageProducer.Transfer(unknown, alice, chain.Value(transferAmnt), chain.Nonce(1))
-		v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
 
 		// Expect message application to fail due to unknow actor when call seq num is also incorrect
 		td.ApplyFailure(
@@ -174,13 +168,13 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		postroot := td.GetStateRoot()
 
-		v.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		v.Pre.StateTree.RootCID = preroot
-		v.Post.StateTree.RootCID = postroot
+		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+		td.Vector.Pre.StateTree.RootCID = preroot
+		td.Vector.Post.StateTree.RootCID = postroot
 
 		// encode and output
 		enc := json.NewEncoder(os.Stdout)
-		if err := enc.Encode(&v); err != nil {
+		if err := enc.Encode(&td.Vector); err != nil {
 			return err
 		}
 
@@ -192,8 +186,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 	err = func(testname string) error {
 		td := drivers.NewTestDriver()
-
-		v := newEmptyMessageVector()
 
 		const pcTimeLock = abi_spec.ChainEpoch(10)
 		const pcLane = uint64(123)
@@ -212,13 +204,13 @@ func MessageTest_MessageApplicationEdgecases() error {
 		receiver, receiverID := td.NewAccountActor(drivers.SECP, initialBal)
 
 		// the _expected_ address of the payment channel
-		paychAddr := chain.MustNewIDAddr(chain.MustIdFromAddress(receiverID) + 1)
+		paychAddr := chain.MustNewIDAddr(chain.MustIDFromAddress(receiverID) + 1)
 		createRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
 
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(0))
-		v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
 
 		td.ApplyExpect(
 			msg,
@@ -239,7 +231,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 				Signature:       pcSig, // construct with invalid signature
 			},
 		}, chain.Nonce(1), chain.Value(big_spec.Zero()))
-		v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
 
 		// message application fails due to invalid argument (signature).
 		td.ApplyFailure(
@@ -248,13 +240,13 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		postroot := td.GetStateRoot()
 
-		v.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		v.Pre.StateTree.RootCID = preroot
-		v.Post.StateTree.RootCID = postroot
+		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+		td.Vector.Pre.StateTree.RootCID = preroot
+		td.Vector.Post.StateTree.RootCID = postroot
 
 		// encode and output
 		enc := json.NewEncoder(os.Stdout)
-		if err := enc.Encode(&v); err != nil {
+		if err := enc.Encode(&td.Vector); err != nil {
 			return err
 		}
 
@@ -267,15 +259,13 @@ func MessageTest_MessageApplicationEdgecases() error {
 	err = func(testname string) error {
 		td := drivers.NewTestDriver()
 
-		v := newEmptyMessageVector()
-
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.MarketComputeDataCommitment(alice, alice, nil, chain.Nonce(0))
 
-		v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
 
 		// message application fails because ComputeDataCommitment isn't defined
 		// on the recipient actor
@@ -285,13 +275,13 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		postroot := td.GetStateRoot()
 
-		v.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		v.Pre.StateTree.RootCID = preroot
-		v.Post.StateTree.RootCID = postroot
+		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+		td.Vector.Pre.StateTree.RootCID = preroot
+		td.Vector.Post.StateTree.RootCID = postroot
 
 		// encode and output
 		enc := json.NewEncoder(os.Stdout)
-		if err := enc.Encode(&v); err != nil {
+		if err := enc.Encode(&td.Vector); err != nil {
 			return err
 		}
 
@@ -304,8 +294,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 	err = func(testname string) error {
 		td := drivers.NewTestDriver()
 
-		v := newEmptyMessageVector()
-
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 
 		preroot := td.GetStateRoot()
@@ -314,7 +302,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		unknownA := chain.MustNewIDAddr(10000000)
 		msg := td.MessageProducer.Transfer(alice, unknownA, chain.Value(transferAmnt), chain.Nonce(0))
 
-		v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
 
 		td.ApplyFailure(
 			msg,
@@ -323,7 +311,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		// Sending a message to non-existing actor address must produce an error.
 		unknownB := chain.MustNewActorAddr("1234")
 		msg = td.MessageProducer.Transfer(alice, unknownB, chain.Value(transferAmnt), chain.Nonce(1))
-		v.ApplyMessages = append(v.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
+		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, Message{Bytes: chain.MustSerialize(msg)})
 
 		td.ApplyFailure(
 			msg,
@@ -331,13 +319,13 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		postroot := td.GetStateRoot()
 
-		v.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		v.Pre.StateTree.RootCID = preroot
-		v.Post.StateTree.RootCID = postroot
+		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+		td.Vector.Pre.StateTree.RootCID = preroot
+		td.Vector.Post.StateTree.RootCID = postroot
 
 		// encode and output
 		enc := json.NewEncoder(os.Stdout)
-		if err := enc.Encode(&v); err != nil {
+		if err := enc.Encode(&td.Vector); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This PR adds a `TestVector` to the `TestDriver` so that test driver methods that apply messages can be recorded in the test vector.

refs #194