### PR TITLE
feat: test driver automatically records applied messages in test vector

### DIFF
--- a/tvx/drivers/test_driver.go
+++ b/tvx/drivers/test_driver.go
@@ -325,10 +325,11 @@ func (td *TestDriver) applyMessage(msg *types.Message) (result vtypes.ApplyMessa
 		}
 	}()
 
-	result, err := td.applier.ApplyMessage(td.ExeCtx.Epoch, msg)
+	epoch := td.ExeCtx.Epoch
+	result, err := td.applier.ApplyMessage(epoch, msg)
 	td.Vector.ApplyMessages = append(
 		td.Vector.ApplyMessages,
-		schema.Message{Epoch: &td.ExeCtx.Epoch, Bytes: chain.MustSerialize(msg)},
+		schema.Message{Epoch: &epoch, Bytes: chain.MustSerialize(msg)},
 	)
 	require.NoError(T, err)
 	return result
@@ -376,10 +377,11 @@ func (td *TestDriver) applyMessageSigned(msg *types.Message) (result vtypes.Appl
 		Message:   *msg,
 		Signature: msgSig,
 	}
-	result, err = td.applier.ApplySignedMessage(td.ExeCtx.Epoch, smsgs)
+	epoch := td.ExeCtx.Epoch
+	result, err = td.applier.ApplySignedMessage(epoch, smsgs)
 	td.Vector.ApplyMessages = append(
 		td.Vector.ApplyMessages,
-		schema.Message{Epoch: &td.ExeCtx.Epoch, Bytes: chain.MustSerialize(smsgs)},
+		schema.Message{Epoch: &epoch, Bytes: chain.MustSerialize(smsgs)},
 	)
 	require.NoError(T, err)
 	return result

--- a/tvx/drivers/test_driver.go
+++ b/tvx/drivers/test_driver.go
@@ -326,13 +326,11 @@ func (td *TestDriver) applyMessage(msg *types.Message) (result vtypes.ApplyMessa
 	}()
 
 	result, err := td.applier.ApplyMessage(td.ExeCtx.Epoch, msg)
-	require.NoError(T, err)
-
 	td.Vector.ApplyMessages = append(
 		td.Vector.ApplyMessages,
 		schema.Message{Bytes: chain.MustSerialize(msg)},
 	)
-
+	require.NoError(T, err)
 	return result
 }
 
@@ -379,13 +377,11 @@ func (td *TestDriver) applyMessageSigned(msg *types.Message) (result vtypes.Appl
 		Signature: msgSig,
 	}
 	result, err = td.applier.ApplySignedMessage(td.ExeCtx.Epoch, smsgs)
-	require.NoError(T, err)
-
 	td.Vector.ApplyMessages = append(
 		td.Vector.ApplyMessages,
 		schema.Message{Bytes: chain.MustSerialize(smsgs)},
 	)
-
+	require.NoError(T, err)
 	return result
 }
 

--- a/tvx/drivers/test_driver.go
+++ b/tvx/drivers/test_driver.go
@@ -328,6 +328,11 @@ func (td *TestDriver) applyMessage(msg *types.Message) (result vtypes.ApplyMessa
 	result, err := td.applier.ApplyMessage(td.ExeCtx.Epoch, msg)
 	require.NoError(T, err)
 
+	td.Vector.ApplyMessages = append(
+		td.Vector.ApplyMessages,
+		schema.Message{Bytes: chain.MustSerialize(msg)},
+	)
+
 	return result
 }
 
@@ -375,6 +380,11 @@ func (td *TestDriver) applyMessageSigned(msg *types.Message) (result vtypes.Appl
 	}
 	result, err = td.applier.ApplySignedMessage(td.ExeCtx.Epoch, smsgs)
 	require.NoError(T, err)
+
+	td.Vector.ApplyMessages = append(
+		td.Vector.ApplyMessages,
+		schema.Message{Bytes: chain.MustSerialize(smsgs)},
+	)
 
 	return result
 }

--- a/tvx/drivers/test_driver.go
+++ b/tvx/drivers/test_driver.go
@@ -328,7 +328,7 @@ func (td *TestDriver) applyMessage(msg *types.Message) (result vtypes.ApplyMessa
 	result, err := td.applier.ApplyMessage(td.ExeCtx.Epoch, msg)
 	td.Vector.ApplyMessages = append(
 		td.Vector.ApplyMessages,
-		schema.Message{Bytes: chain.MustSerialize(msg)},
+		schema.Message{Epoch: &td.ExeCtx.Epoch, Bytes: chain.MustSerialize(msg)},
 	)
 	require.NoError(T, err)
 	return result
@@ -379,7 +379,7 @@ func (td *TestDriver) applyMessageSigned(msg *types.Message) (result vtypes.Appl
 	result, err = td.applier.ApplySignedMessage(td.ExeCtx.Epoch, smsgs)
 	td.Vector.ApplyMessages = append(
 		td.Vector.ApplyMessages,
-		schema.Message{Bytes: chain.MustSerialize(smsgs)},
+		schema.Message{Epoch: &td.ExeCtx.Epoch, Bytes: chain.MustSerialize(smsgs)},
 	)
 	require.NoError(T, err)
 	return result

--- a/tvx/suite_messages_create_actor.go
+++ b/tvx/suite_messages_create_actor.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/filecoin-project/oni/tvx/chain"
 	"github.com/filecoin-project/oni/tvx/drivers"
-	"github.com/filecoin-project/oni/tvx/schema"
 )
 
 var suiteMessagesCmd = &cli.Command{
@@ -96,11 +95,6 @@ func MessageTest_AccountActorCreation() error {
 			preroot := td.GetStateRoot()
 
 			msg := td.MessageProducer.Transfer(existingAccountAddr, tc.newActorAddr, chain.Value(tc.newActorInitBal), chain.Nonce(0))
-			b, err := msg.Serialize()
-			if err != nil {
-				return err
-			}
-			td.Vector.ApplyMessages = []schema.Message{{Bytes: b}}
 			result := td.ApplyFailure(
 				msg,
 				tc.expExitCode,
@@ -156,23 +150,11 @@ func MessageTest_InitActorSequentialIDAddressCreate() error {
 		chain.MustSerialize(&firstInitRet),
 	)
 
-	b1, err := msg1.Serialize()
-	if err != nil {
-		return err
-	}
-	td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: b1})
-
 	msg2 := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(1))
 	td.ApplyExpect(
 		msg2,
 		chain.MustSerialize(&secondInitRet),
 	)
-
-	b2, err := msg2.Serialize()
-	if err != nil {
-		return err
-	}
-	td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: b2})
 
 	postroot := td.GetStateRoot()
 

--- a/tvx/suite_messages_message_application.go
+++ b/tvx/suite_messages_message_application.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/filecoin-project/oni/tvx/chain"
 	"github.com/filecoin-project/oni/tvx/drivers"
-	"github.com/filecoin-project/oni/tvx/schema"
 )
 
 func MessageTest_MessageApplicationEdgecases() error {
@@ -27,7 +26,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(1), chain.GasLimit(8))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		td.ApplyFailure(
 			msg,
@@ -55,7 +53,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		preroot := td.GetStateRoot()
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(10), chain.GasLimit(1))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// Expect Message application to fail due to lack of gas
 		td.ApplyFailure(
@@ -64,7 +61,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		unknown := chain.MustNewIDAddr(10000000)
 		msg = td.MessageProducer.Transfer(unknown, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(10), chain.GasLimit(1))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// Expect Message application to fail due to lack of gas when sender is unknown
 		td.ApplyFailure(
@@ -100,7 +96,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 		newAccountA := chain.MustNewSECP256K1Addr("1")
 
 		msg := td.MessageProducer.Transfer(alice, newAccountA, chain.Value(transferAmnt), chain.Nonce(aliceNonceF()))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// get the "true" gas cost of applying the message
 		result := td.ApplyOk(msg)
@@ -111,7 +106,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 		newAccountB := chain.MustNewSECP256K1Addr("2")
 		for tryGas := trueGas - gasStep; tryGas > 0; tryGas -= gasStep {
 			msg := td.MessageProducer.Transfer(alice, newAccountB, chain.Value(transferAmnt), chain.Nonce(aliceNonceF()), chain.GasPrice(1), chain.GasLimit(tryGas))
-			td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 			td.ApplyFailure(
 				msg,
@@ -142,7 +136,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(1))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// Expect Message application to fail due to callseqnum being invalid: 1 instead of 0
 		td.ApplyFailure(
@@ -151,7 +144,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		unknown := chain.MustNewIDAddr(10000000)
 		msg = td.MessageProducer.Transfer(unknown, alice, chain.Value(transferAmnt), chain.Nonce(1))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// Expect message application to fail due to unknow actor when call seq num is also incorrect
 		td.ApplyFailure(
@@ -199,7 +191,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(0))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		td.ApplyExpect(
 			msg,
@@ -220,7 +211,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 				Signature:       pcSig, // construct with invalid signature
 			},
 		}, chain.Nonce(1), chain.Value(big_spec.Zero()))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// message application fails due to invalid argument (signature).
 		td.ApplyFailure(
@@ -250,8 +240,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.MarketComputeDataCommitment(alice, alice, nil, chain.Nonce(0))
-
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// message application fails because ComputeDataCommitment isn't defined
 		// on the recipient actor
@@ -285,8 +273,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 		unknownA := chain.MustNewIDAddr(10000000)
 		msg := td.MessageProducer.Transfer(alice, unknownA, chain.Value(transferAmnt), chain.Nonce(0))
 
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
-
 		td.ApplyFailure(
 			msg,
 			exitcode_spec.SysErrInvalidReceiver)
@@ -294,7 +280,6 @@ func MessageTest_MessageApplicationEdgecases() error {
 		// Sending a message to non-existing actor address must produce an error.
 		unknownB := chain.MustNewActorAddr("1234")
 		msg = td.MessageProducer.Transfer(alice, unknownB, chain.Value(transferAmnt), chain.Nonce(1))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		td.ApplyFailure(
 			msg,

--- a/tvx/suite_messages_paych.go
+++ b/tvx/suite_messages_paych.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/filecoin-project/oni/tvx/chain"
 	"github.com/filecoin-project/oni/tvx/drivers"
-	"github.com/filecoin-project/oni/tvx/schema"
 )
 
 func MessageTest_Paych() error {
@@ -35,7 +34,6 @@ func MessageTest_Paych() error {
 		createRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
 
 		msg := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(0))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 
 		// init actor creates the payment channel
 		td.ApplyExpect(
@@ -89,7 +87,6 @@ func MessageTest_Paych() error {
 		createRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
 
 		msg := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(0))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 		td.ApplyExpect(
 			msg,
 			chain.MustSerialize(&createRet))
@@ -109,7 +106,6 @@ func MessageTest_Paych() error {
 				Signature:       pcSig,
 			},
 		}, chain.Nonce(1), chain.Value(big_spec.Zero()))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 		td.ApplyOk(msg)
 
 		var pcState paych_spec.State
@@ -147,7 +143,6 @@ func MessageTest_Paych() error {
 		preroot := td.GetStateRoot()
 
 		msg := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(0))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 		td.ApplyExpect(
 			msg,
 			chain.MustSerialize(&initRet))
@@ -172,22 +167,17 @@ func MessageTest_Paych() error {
 			},
 		}, chain.Nonce(1), chain.Value(big_spec.Zero()))
 
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
-
 		td.ApplyOk(msg)
 
 		// settle the payment channel so it may be collected
 
 		msg = td.MessageProducer.PaychSettle(receiver, paychAddr, nil, chain.Value(big_spec.Zero()), chain.Nonce(0))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Bytes: chain.MustSerialize(msg)})
 		settleResult := td.ApplyOk(msg)
 
 		// advance the epoch so the funds may be redeemed.
 		td.ExeCtx.Epoch += paych_spec.SettleDelay
 
 		msg = td.MessageProducer.PaychCollect(receiver, paychAddr, nil, chain.Nonce(1), chain.Value(big_spec.Zero()))
-		td.Vector.ApplyMessages = append(td.Vector.ApplyMessages, schema.Message{Epoch: &td.ExeCtx.Epoch, Bytes: chain.MustSerialize(msg)})
-
 		collectResult := td.ApplyOk(msg)
 
 		// receiver_balance = initial_balance + paych_send - settle_paych_msg_gas - collect_paych_msg_gas


### PR DESCRIPTION
The `TestDriver` now records applied messages in it's `TestVector` whenever an `Apply*` method is called. This removes the need for manual message serialization and recording in the tests.