### PR TITLE
refactor getting post root and serialize of test vector

### DIFF
--- a/tvx/drivers/test_driver.go
+++ b/tvx/drivers/test_driver.go
@@ -558,6 +558,22 @@ func (td *TestDriver) GetStateRoot() cid.Cid {
 	return td.st.stateRoot
 }
 
+func (td *TestDriver) UpdatePreStateRoot() {
+	td.Vector.Pre.StateTree.RootCID = td.st.stateRoot
+}
+
+func (td *TestDriver) UpdatePostStateRoot() {
+	td.Vector.Post.StateTree.RootCID = td.st.stateRoot
+}
+
+func (td *TestDriver) MustSerialize(w io.Writer) {
+	td.Vector.Post.StateTree.RootCID = td.st.stateRoot
+
+	td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, td.Vector.Post.StateTree.RootCID)
+
+	fmt.Fprintln(w, string(td.Vector.MustMarshalJSON()))
+}
+
 func (td *TestDriver) MustMarshalGzippedCAR(roots ...cid.Cid) []byte {
 	var b bytes.Buffer
 	gw := gzip.NewWriter(&b)

--- a/tvx/suite_messages_create_actor.go
+++ b/tvx/suite_messages_create_actor.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/hashicorp/go-multierror"
@@ -95,7 +94,7 @@ func MessageTest_AccountActorCreation() error {
 
 			existingAccountAddr, _ := td.NewAccountActor(tc.existingActorType, tc.existingActorBal)
 
-			preroot := td.GetStateRoot()
+			td.UpdatePreStateRoot()
 
 			msg := td.MessageProducer.Transfer(existingAccountAddr, tc.newActorAddr, chain.Value(tc.newActorInitBal), chain.Nonce(0))
 			result := td.ApplyFailure(
@@ -109,14 +108,7 @@ func MessageTest_AccountActorCreation() error {
 				td.AssertBalance(existingAccountAddr, big_spec.Sub(big_spec.Sub(tc.existingActorBal, result.Receipt.GasUsed.Big()), tc.newActorInitBal))
 			}
 
-			postroot := td.GetStateRoot()
-
-			td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-			td.Vector.Pre.StateTree.RootCID = preroot
-			td.Vector.Post.StateTree.RootCID = postroot
-
-			// encode and output
-			fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+			td.MustSerialize(os.Stdout)
 
 			return nil
 		}()
@@ -145,7 +137,7 @@ func MessageTest_InitActorSequentialIDAddressCreate() error {
 	firstInitRet := td.ComputeInitActorExecReturn(sender, 0, 0, firstPaychAddr)
 	secondInitRet := td.ComputeInitActorExecReturn(sender, 1, 0, secondPaychAddr)
 
-	preroot := td.GetStateRoot()
+	td.UpdatePreStateRoot()
 
 	msg1 := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(0))
 	td.ApplyExpect(
@@ -159,14 +151,7 @@ func MessageTest_InitActorSequentialIDAddressCreate() error {
 		chain.MustSerialize(&secondInitRet),
 	)
 
-	postroot := td.GetStateRoot()
-
-	td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-	td.Vector.Pre.StateTree.RootCID = preroot
-	td.Vector.Post.StateTree.RootCID = postroot
-
-	// encode and output
-	fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+	td.MustSerialize(os.Stdout)
 
 	return nil
 }

--- a/tvx/suite_messages_message_application.go
+++ b/tvx/suite_messages_message_application.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	abi_spec "github.com/filecoin-project/specs-actors/actors/abi"
@@ -23,7 +22,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(1), chain.GasLimit(8))
 
@@ -31,14 +30,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 			msg,
 			exitcode_spec.SysErrOutOfGas)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail to cover gas cost for message receipt on chain")
@@ -51,7 +43,8 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
+
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(10), chain.GasLimit(1))
 
 		// Expect Message application to fail due to lack of gas
@@ -67,14 +60,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 			msg,
 			exitcode_spec.SysErrOutOfGas)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("not enough gas to pay message on-chain-size cost")
@@ -86,7 +72,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		td := drivers.NewTestDriver()
 
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		aliceNonce := uint64(0)
 		aliceNonceF := func() uint64 {
@@ -113,14 +99,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 			)
 		}
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail not enough gas to cover account actor creation")
@@ -133,7 +112,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(1))
 
@@ -150,14 +129,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 			msg,
 			exitcode_spec.SysErrSenderInvalid)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("invalid actor nonce")
@@ -188,7 +160,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 		paychAddr := chain.MustNewIDAddr(chain.MustIDFromAddress(receiverID) + 1)
 		createRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(0))
 
@@ -217,14 +189,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 			msg,
 			exitcode_spec.ErrIllegalArgument)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("abort during actor execution")
@@ -237,7 +202,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.MarketComputeDataCommitment(alice, alice, nil, chain.Nonce(0))
 
@@ -247,14 +212,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 			msg,
 			exitcode_spec.SysErrInvalidMethod)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("invalid method for receiver")
@@ -267,7 +225,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		// Sending a message to non-existent ID address must produce an error.
 		unknownA := chain.MustNewIDAddr(10000000)
@@ -285,14 +243,7 @@ func MessageTest_MessageApplicationEdgecases() error {
 			msg,
 			exitcode_spec.SysErrInvalidReceiver)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("receiver ID/Actor address does not exist")

--- a/tvx/suite_messages_nested.go
+++ b/tvx/suite_messages_nested.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 
 	address "github.com/filecoin-project/go-address"
@@ -57,13 +56,7 @@ func MessageTest_NestedSends() error {
 
 		td.AssertActor(stage.creator, big.Sub(big.Add(balanceBefore, amtSent), result.Receipt.GasUsed.Big()), nonce+1)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("ok basic")
@@ -87,13 +80,7 @@ func MessageTest_NestedSends() error {
 		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.Big()))
 		td.AssertBalance(newAddr, amtSent)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("ok to new actor")
@@ -123,13 +110,7 @@ func MessageTest_NestedSends() error {
 		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.Big()))
 		td.AssertBalance(newAddr, amtSent)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("ok to new actor with invoke")
@@ -158,13 +139,7 @@ func MessageTest_NestedSends() error {
 		td.GetActorState(stage.msAddr, &st)
 		assert.Equal(drivers.T, []address.Address{stage.creator, anotherId}, st.Signers)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("ok recursive")
@@ -187,13 +162,7 @@ func MessageTest_NestedSends() error {
 		td.AssertBalance(stage.msAddr, big.Sub(multisigBalance, amtSent))
 		td.AssertBalance(newAddr, amtSent)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("ok non-CBOR params with transfer")
@@ -231,13 +200,7 @@ func MessageTest_NestedSends() error {
 		_, err := td.State().Actor(newAddr)
 		assert.Error(drivers.T, err)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail nonexistent ID address")
@@ -259,13 +222,7 @@ func MessageTest_NestedSends() error {
 		_, err := td.State().Actor(newAddr)
 		assert.Error(drivers.T, err)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail nonexistent actor address")
@@ -286,13 +243,7 @@ func MessageTest_NestedSends() error {
 		td.AssertBalance(stage.msAddr, multisigBalance) // No change.
 		td.AssertNoActor(newAddr)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail invalid methodnum new actor")
@@ -313,13 +264,7 @@ func MessageTest_NestedSends() error {
 		td.AssertBalance(stage.msAddr, multisigBalance)                                       // No change.
 		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.Big())) // Pay gas, don't receive funds.
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail invalid methodnum for actor")
@@ -361,13 +306,7 @@ func MessageTest_NestedSends() error {
 		td.AssertBalance(stage.msAddr, multisigBalance)        // No change.
 		assert.Equal(drivers.T, 1, len(stage.state().Signers)) // No new signers
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail missing params")
@@ -396,13 +335,7 @@ func MessageTest_NestedSends() error {
 		td.AssertBalance(stage.msAddr, multisigBalance)        // No change.
 		assert.Equal(drivers.T, 1, len(stage.state().Signers)) // No new signers
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail mismatched params")
@@ -429,13 +362,7 @@ func MessageTest_NestedSends() error {
 		td.AssertBalance(stage.msAddr, multisigBalance) // No change.
 		td.AssertHead(builtin.RewardActorAddr, prevHead)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail inner abort")
@@ -466,13 +393,7 @@ func MessageTest_NestedSends() error {
 		td.AssertBalance(stage.msAddr, multisigBalance) // No change.
 		td.AssertHead(builtin.InitActorAddr, prevHead)  // Init state unchanged.
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail aborted exec")
@@ -519,13 +440,7 @@ func MessageTest_NestedSends() error {
 		td.AssertBalance(alice, big.Sub(acctDefaultBalance, result.GasUsed().Big()))
 		td.AssertBalance(bob, big.Zero())
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(td.Vector.Pre.StateTree.RootCID, postroot)
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail insufficient funds for transfer in inner send")
@@ -553,8 +468,7 @@ func prepareStage(td *drivers.TestDriver, creatorBalance, msBalance abi.TokenAmo
 
 	msg := td.MessageProducer.CreateMultisigActor(creatorId, []address.Address{creatorId}, 0, 1, chain.Value(msBalance), chain.Nonce(0))
 
-	preroot := td.GetStateRoot()
-	td.Vector.Pre.StateTree.RootCID = preroot
+	td.UpdatePreStateRoot()
 
 	result := td.ApplyMessage(msg)
 	require.Equal(drivers.T, exitcode_spec.Ok, result.Receipt.ExitCode)

--- a/tvx/suite_messages_paych.go
+++ b/tvx/suite_messages_paych.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	abi_spec "github.com/filecoin-project/specs-actors/actors/abi"
@@ -27,7 +26,7 @@ func MessageTest_Paych() error {
 		// will be receiver on paych
 		receiver, receiverID := td.NewAccountActor(drivers.SECP, initialBal)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		// the _expected_ address of the payment channel
 		paychAddr := chain.MustNewIDAddr(chain.MustIDFromAddress(receiverID) + 1)
@@ -46,14 +45,7 @@ func MessageTest_Paych() error {
 		assert.Equal(drivers.T, receiverID, pcState.To)
 		td.AssertBalance(paychAddr, toSend)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("happy path constructor")
@@ -80,7 +72,7 @@ func MessageTest_Paych() error {
 		// will be receiver on paych
 		receiver, receiverID := td.NewAccountActor(drivers.SECP, initialBal)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		// the _expected_ address of the payment channel
 		paychAddr := chain.MustNewIDAddr(chain.MustIDFromAddress(receiverID) + 1)
@@ -116,14 +108,7 @@ func MessageTest_Paych() error {
 		assert.Equal(drivers.T, pcNonce, ls.Nonce)
 		assert.Equal(drivers.T, pcLane, ls.ID)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("happy path update")
@@ -140,7 +125,7 @@ func MessageTest_Paych() error {
 		paychAddr := chain.MustNewIDAddr(chain.MustIDFromAddress(receiverID) + 1)
 		initRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(0))
 		td.ApplyExpect(
@@ -185,14 +170,7 @@ func MessageTest_Paych() error {
 		// the paych actor should have been deleted after the collect
 		td.AssertNoActor(paychAddr)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("happy path collect")

--- a/tvx/suite_messages_transfer.go
+++ b/tvx/suite_messages_transfer.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	address "github.com/filecoin-project/go-address"
@@ -108,7 +107,7 @@ func MessageTest_ValueTransferSimple() error {
 			require.NoError(drivers.T, err)
 			require.Equal(drivers.T, tc.senderBal.String(), sendAct.Balance().String())
 
-			preroot := td.GetStateRoot()
+			td.UpdatePreStateRoot()
 
 			msg := td.MessageProducer.Transfer(tc.sender, tc.receiver, chain.Value(tc.transferAmnt), chain.Nonce(0))
 
@@ -130,14 +129,7 @@ func MessageTest_ValueTransferSimple() error {
 				}
 			}
 
-			postroot := td.GetStateRoot()
-
-			td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-			td.Vector.Pre.StateTree.RootCID = preroot
-			td.Vector.Post.StateTree.RootCID = postroot
-
-			// encode and output
-			fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+			td.MustSerialize(os.Stdout)
 
 			return nil
 		}(tc.desc)
@@ -158,7 +150,7 @@ func MessageTest_ValueTransferAdvance() error {
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceInitialBalance)
 		transferAmnt := abi_spec.NewTokenAmount(10)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0))
 		result := td.ApplyOk(msg)
@@ -166,14 +158,7 @@ func MessageTest_ValueTransferAdvance() error {
 		// since this is a self transfer expect alice's balance to only decrease by the gasUsed
 		td.AssertBalance(alice, big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed.Big()))
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("self transfer secp to secp")
@@ -187,7 +172,7 @@ func MessageTest_ValueTransferAdvance() error {
 		alice, aliceId := td.NewAccountActor(drivers.SECP, aliceInitialBalance)
 		transferAmnt := abi_spec.NewTokenAmount(10)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.Transfer(alice, aliceId, chain.Value(transferAmnt), chain.Nonce(0))
 
@@ -196,14 +181,7 @@ func MessageTest_ValueTransferAdvance() error {
 		// since this is a self transfer expect alice's balance to only decrease by the gasUsed
 		td.AssertBalance(alice, big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed.Big()))
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("self transfer secp to id address")
@@ -217,7 +195,7 @@ func MessageTest_ValueTransferAdvance() error {
 		alice, aliceId := td.NewAccountActor(drivers.SECP, aliceInitialBalance)
 		transferAmnt := abi_spec.NewTokenAmount(10)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.Transfer(aliceId, alice, chain.Value(transferAmnt), chain.Nonce(0))
 
@@ -226,14 +204,7 @@ func MessageTest_ValueTransferAdvance() error {
 		// since this is a self transfer expect alice's balance to only decrease by the gasUsed
 		td.AssertBalance(alice, big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed.Big()))
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("self transfer id to secp address")
@@ -247,7 +218,7 @@ func MessageTest_ValueTransferAdvance() error {
 		alice, aliceId := td.NewAccountActor(drivers.SECP, aliceInitialBalance)
 		transferAmnt := abi_spec.NewTokenAmount(10)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.Transfer(aliceId, aliceId, chain.Value(transferAmnt), chain.Nonce(0))
 
@@ -256,14 +227,7 @@ func MessageTest_ValueTransferAdvance() error {
 		// since this is a self transfer expect alice's balance to only decrease by the gasUsed
 		td.AssertBalance(alice, big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed.Big()))
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("self transfer id to id address")
@@ -278,7 +242,7 @@ func MessageTest_ValueTransferAdvance() error {
 		receiver := td.Wallet().NewSECP256k1AccountAddress()
 		transferAmnt := abi_spec.NewTokenAmount(10)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.Transfer(alice, receiver, chain.Value(transferAmnt), chain.Nonce(0))
 
@@ -286,14 +250,7 @@ func MessageTest_ValueTransferAdvance() error {
 		td.AssertBalance(alice, big_spec.Sub(big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed.Big()), transferAmnt))
 		td.AssertBalance(receiver, transferAmnt)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("ok transfer from known address to new account")
@@ -308,7 +265,7 @@ func MessageTest_ValueTransferAdvance() error {
 		unknown := td.Wallet().NewSECP256k1AccountAddress()
 		transferAmnt := abi_spec.NewTokenAmount(10)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.Transfer(unknown, alice, chain.Value(transferAmnt), chain.Nonce(0))
 
@@ -317,14 +274,7 @@ func MessageTest_ValueTransferAdvance() error {
 			exitcode_spec.SysErrSenderInvalid)
 		td.AssertBalance(alice, aliceInitialBalance)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail to transfer from unknown account to known address")
@@ -339,7 +289,7 @@ func MessageTest_ValueTransferAdvance() error {
 		receiver := td.Wallet().NewSECP256k1AccountAddress()
 		transferAmnt := abi_spec.NewTokenAmount(10)
 
-		preroot := td.GetStateRoot()
+		td.UpdatePreStateRoot()
 
 		msg := td.MessageProducer.Transfer(sender, receiver, chain.Value(transferAmnt), chain.Nonce(0))
 
@@ -349,14 +299,7 @@ func MessageTest_ValueTransferAdvance() error {
 		td.AssertNoActor(sender)
 		td.AssertNoActor(receiver)
 
-		postroot := td.GetStateRoot()
-
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
-		td.Vector.Pre.StateTree.RootCID = preroot
-		td.Vector.Post.StateTree.RootCID = postroot
-
-		// encode and output
-		fmt.Fprintln(os.Stdout, string(td.Vector.MustMarshalJSON()))
+		td.MustSerialize(os.Stdout)
 
 		return nil
 	}("fail to transfer from unknown address to unknown address")


### PR DESCRIPTION
A small refactor pushing the serialisation of the test vector to the test driver, since we are going to need this for every single test we run, and it is safe to assume that we will have a one-to-one relationship between test driver <-> test vector.