### PR TITLE
refactor: switch to brotli+base64 encoding for binary data

### DIFF
--- a/tvx/drivers/test_driver.go
+++ b/tvx/drivers/test_driver.go
@@ -577,12 +577,13 @@ func (td *TestDriver) MustSerialize(w io.Writer) {
 func (td *TestDriver) MustMarshalBrotliCAR(roots ...cid.Cid) []byte {
 	var b bytes.Buffer
 	bw := cbrotli.NewWriter(&b, cbrotli.WriterOptions{Quality: 11})
-	defer bw.Close()
 
 	err := td.MarshalCAR(bw, roots...)
 	if err != nil {
 		panic(err)
 	}
+
+	bw.Close()
 
 	return b.Bytes()
 }

--- a/tvx/exec_lotus.go
+++ b/tvx/exec_lotus.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/blockstore"
+	"github.com/google/brotli/go/cbrotli"
 	"github.com/ipld/go-car"
 	"github.com/urfave/cli/v2"
 
@@ -87,13 +87,10 @@ func executeTestVector(tv schema.TestVector) error {
 		bs := blockstore.NewTemporary()
 
 		buf := bytes.NewReader(tv.CAR)
-		gr, err := gzip.NewReader(buf)
-		if err != nil {
-			return err
-		}
-		defer gr.Close()
+		br := cbrotli.NewReader(buf)
+		defer br.Close()
 
-		header, err := car.LoadCar(bs, gr)
+		header, err := car.LoadCar(bs, br)
 		if err != nil {
 			return fmt.Errorf("failed to load state tree car from test vector: %w", err)
 		}

--- a/tvx/extract_msg.go
+++ b/tvx/extract_msg.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,6 +9,7 @@ import (
 	"os"
 
 	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/google/brotli/go/cbrotli"
 	"github.com/ipfs/go-cid"
 	"github.com/urfave/cli/v2"
 
@@ -162,14 +162,15 @@ func runExtractMsg(c *cli.Context) error {
 	}
 
 	out := new(bytes.Buffer)
-	gw := gzip.NewWriter(out)
-	if err := g.WriteCAR(gw, preroot, postroot); err != nil {
+
+	bw := cbrotli.NewWriter(out, cbrotli.WriterOptions{Quality: 11})
+	if err := g.WriteCAR(bw, preroot, postroot); err != nil {
 		return err
 	}
-	if err = gw.Flush(); err != nil {
+	if err = bw.Flush(); err != nil {
 		return err
 	}
-	if err = gw.Close(); err != nil {
+	if err = bw.Close(); err != nil {
 		return err
 	}
 

--- a/tvx/go.mod
+++ b/tvx/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/filecoin-project/lotus v0.4.3-0.20200803225238-cd8537e76fc0
 	github.com/filecoin-project/sector-storage v0.0.0-20200803184904-3cab915fd225
 	github.com/filecoin-project/specs-actors v0.8.6
+	github.com/google/brotli v1.0.7
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.4-0.20200624145336-a978cec6e834

--- a/tvx/go.sum
+++ b/tvx/go.sum
@@ -329,6 +329,8 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/brotli v1.0.7 h1:fxwwohNEPaVS6qvtnjwgzRR62Upa70pkw0f9qarjrQs=
+github.com/google/brotli v1.0.7/go.mod h1:XpGqLY1HgMKTQI5TU8iAKE/okaKqS9h1e6KRlRztlOU=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/tvx/schema/schema.go
+++ b/tvx/schema/schema.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"encoding/hex"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -47,10 +47,8 @@ type StateTree struct {
 	RootCID cid.Cid `json:"root_cid"`
 }
 
-// HexEncodedBytes is a hex-encoded binary value.
-//
-// TODO may switch to base64 or base85 for efficiency.
-type HexEncodedBytes []byte
+// Base64EncodedBytes is a base64-encoded binary value.
+type Base64EncodedBytes []byte
 
 // Preconditions contain a representation of VM state at the beginning of the test
 type Preconditions struct {
@@ -60,9 +58,9 @@ type Preconditions struct {
 
 // Receipt represents a receipt to match against.
 type Receipt struct {
-	ExitCode    exitcode.ExitCode `json:"exit_code"`
-	ReturnValue HexEncodedBytes   `json:"return"`
-	GasUsed     int64             `json:"gas_used"`
+	ExitCode    exitcode.ExitCode  `json:"exit_code"`
+	ReturnValue Base64EncodedBytes `json:"return"`
+	GasUsed     int64              `json:"gas_used"`
 }
 
 // Postconditions contain a representation of VM state at th end of the test
@@ -71,23 +69,23 @@ type Postconditions struct {
 	Receipts  []*Receipt `json:"receipts"`
 }
 
-// MarshalJSON implements json.Marshal for HexEncodedBytes
-func (heb HexEncodedBytes) MarshalJSON() ([]byte, error) {
-	return json.Marshal(hex.EncodeToString(heb))
+// MarshalJSON implements json.Marshal for Base64EncodedBytes
+func (beb Base64EncodedBytes) MarshalJSON() ([]byte, error) {
+	return json.Marshal(base64.StdEncoding.EncodeToString(beb))
 }
 
-// UnmarshalJSON implements json.Unmarshal for HexEncodedBytes
-func (heb *HexEncodedBytes) UnmarshalJSON(v []byte) error {
+// UnmarshalJSON implements json.Unmarshal for Base64EncodedBytes
+func (beb *Base64EncodedBytes) UnmarshalJSON(v []byte) error {
 	var s string
 	if err := json.Unmarshal(v, &s); err != nil {
 		return err
 	}
 
-	bytes, err := hex.DecodeString(s)
+	bytes, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
 		return err
 	}
-	*heb = bytes
+	*beb = bytes
 	return nil
 }
 
@@ -100,7 +98,7 @@ type TestVector struct {
 	// CAR binary data to be loaded into the test environment, usually a CAR
 	// containing multiple state trees, addressed by root CID from the relevant
 	// objects.
-	CAR HexEncodedBytes `json:"car_hex"`
+	CAR Base64EncodedBytes `json:"car"`
 
 	Pre           *Preconditions  `json:"preconditions"`
 	ApplyMessages []Message       `json:"apply_messages"`
@@ -108,8 +106,8 @@ type TestVector struct {
 }
 
 type Message struct {
-	Bytes HexEncodedBytes `json:"bytes"`
-	Epoch *abi.ChainEpoch `json:"epoch,omitempty"`
+	Bytes Base64EncodedBytes `json:"bytes"`
+	Epoch *abi.ChainEpoch    `json:"epoch,omitempty"`
 }
 
 // Validate validates this test vector against the JSON schema, and applies

--- a/tvx/state/serialize.go
+++ b/tvx/state/serialize.go
@@ -2,16 +2,16 @@ package state
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"fmt"
 
 	"github.com/filecoin-project/lotus/chain/state"
 	bs "github.com/filecoin-project/lotus/lib/blockstore"
+	"github.com/google/brotli/go/cbrotli"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-hamt-ipld"
 	cbor "github.com/ipfs/go-ipld-cbor"
-	"github.com/ipfs/go-ipld-format"
+	format "github.com/ipfs/go-ipld-format"
 	"github.com/ipld/go-car"
 )
 
@@ -19,13 +19,10 @@ import (
 func RecoverStateTree(ctx context.Context, raw []byte, root cid.Cid) (*state.StateTree, error) {
 	buf := bytes.NewBuffer(raw)
 	store := bs.NewTemporary()
-	gr, err := gzip.NewReader(buf)
-	if err != nil {
-		return nil, err
-	}
-	defer gr.Close()
+	br := cbrotli.NewReader(buf)
+	defer br.Close()
 
-	ch, err := car.LoadCar(store, gr)
+	ch, err := car.LoadCar(store, br)
 	if err != nil {
 		return nil, err
 	}

--- a/tvx/suite_messages_multisig.go
+++ b/tvx/suite_messages_multisig.go
@@ -44,7 +44,7 @@ func MessageTest_MultiSigActor() error {
 
 		postroot := td.GetStateRoot()
 
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+		td.Vector.CAR = td.MustMarshalBrotliCAR(preroot, postroot)
 		td.Vector.Pre.StateTree.RootCID = preroot
 		td.Vector.Post.StateTree.RootCID = postroot
 
@@ -138,7 +138,7 @@ func MessageTest_MultiSigActor() error {
 
 		postroot := td.GetStateRoot()
 
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+		td.Vector.CAR = td.MustMarshalBrotliCAR(preroot, postroot)
 		td.Vector.Pre.StateTree.RootCID = preroot
 		td.Vector.Post.StateTree.RootCID = postroot
 
@@ -252,7 +252,7 @@ func MessageTest_MultiSigActor() error {
 
 		postroot := td.GetStateRoot()
 
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+		td.Vector.CAR = td.MustMarshalBrotliCAR(preroot, postroot)
 		td.Vector.Pre.StateTree.RootCID = preroot
 		td.Vector.Post.StateTree.RootCID = postroot
 
@@ -337,7 +337,7 @@ func MessageTest_MultiSigActor() error {
 
 		postroot := td.GetStateRoot()
 
-		td.Vector.CAR = td.MustMarshalGzippedCAR(preroot, postroot)
+		td.Vector.CAR = td.MustMarshalBrotliCAR(preroot, postroot)
 		td.Vector.Pre.StateTree.RootCID = preroot
 		td.Vector.Post.StateTree.RootCID = postroot
 


### PR DESCRIPTION
~32% smaller vectors:

```console
$ ./tvx suite-messages > vectors.brotli.b64.ndjson
$ ls -lah vectors.*
-rw-r--r--  1 alan  staff   119K 14 Aug 16:07 vectors.gzip.brotli.ndjson
-rw-r--r--  1 alan  staff   174K 14 Aug 11:31 vectors.gzip.hex.ndjson
```

Note, only ~3% smaller than [gzip+base64](https://github.com/filecoin-project/oni/pull/233).

refs #183