### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ make
 7. Run a composition for the baseline deals end-to-end test case
 
 ```
-testground run composition -f ./lotus-soup/_compositions/baseline.toml
+testground run composition -f ./lotus-soup/_compositions/baseline-docker-5-1.toml
 ```
 
 ## Batch-running randomised test cases


### PR DESCRIPTION
Update command in README to use `local:docker` and `local:exec`, as at the moment we don't have all the commands explained for `local:exec` (i.e. one has to install all dependencies to be able to compile `filecoin-ffi`, which are a lot: https://github.com/filecoin-project/oni/blob/master/docker-images/Dockerfile.oni-buildbase#L5) and has to also download and copy proof parameters in `/var/tmp/`

All this is automated in the `local:docker` setup, so it is easier to get started with the `local:docker` composition version.