### PR TITLE
clone fil-blst in extra for the local:docker runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ download-proofs:
 	go run github.com/filecoin-project/go-paramfetch/paramfetch 2048 ./docker-images/proof-parameters.json
 
 build-images:
-	docker build -t "iptestground/oni-buildbase:v6" -f "docker-images/Dockerfile.oni-buildbase" "docker-images"
+	docker build -t "iptestground/oni-buildbase:v7" -f "docker-images/Dockerfile.oni-buildbase" "docker-images"
 	docker build -t "iptestground/oni-runtime:v3" -f "docker-images/Dockerfile.oni-runtime" "docker-images"
 	docker build -t "iptestground/oni-runtime:v4-debug" -f "docker-images/Dockerfile.oni-runtime-debug" "docker-images"
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Additional to the Filecoin FFI Git submodules, we are also bundling `proof param
 * `v4` => locking in Filecoin FFI commit 6a143e06f923f3a4f544c7a652e8b4df420a3d28.
 * `v5` => locking in Filecoin FFI commit cddc56607e1d851ea6d09d49404bd7db70cb3c2e.
 * `v6` => locking in Filecoin FFI commit 40569104603407c999d6c9e4c3f1228cbd4d0e5c.
+* `v7` => add Filecoin-BLST repo to buildbase.
 
 
 ### oni-runtime

--- a/docker-images/Dockerfile.oni-buildbase
+++ b/docker-images/Dockerfile.oni-buildbase
@@ -12,3 +12,11 @@ RUN mkdir -p ${FFI_DIR} \
     && cd ${FFI_DIR} \
     && git checkout ${FILECOIN_FFI_COMMIT} \
     && make
+
+ARG FIL_BLST_COMMIT=5f93488
+ARG BLST_DIR=/extra/fil-blst
+
+RUN mkdir -p ${BLST_DIR} \
+    && git clone https://github.com/filecoin-project/fil-blst.git ${BLST_DIR} \
+    && cd ${BLST_DIR} \
+    && git checkout ${FIL_BLST_COMMIT}

--- a/lotus-soup/manifest.toml
+++ b/lotus-soup/manifest.toml
@@ -1,5 +1,5 @@
 name = "lotus-soup"
-extra_sources = { "exec:go" = ["../extra/filecoin-ffi"] }
+extra_sources = { "exec:go" = ["../extra/filecoin-ffi", "../extra/fil-blst"] }
 
 [defaults]
 builder = "docker:go"
@@ -10,7 +10,7 @@ enabled = true
 
 [builders."docker:go"]
 enabled = true
-build_base_image = "iptestground/oni-buildbase:v6"
+build_base_image = "iptestground/oni-buildbase:v7"
 runtime_image = "iptestground/oni-runtime:v4-debug"
 
 [runners."local:exec"]


### PR DESCRIPTION
Follow up to https://github.com/filecoin-project/oni/pull/254

We need to have the `fil-blst` as part of the docker image `buildbase` when using the `local:docker` testground runner.

We also need to upload that folder as part of the extra sources when using the `local:exec` runner.