### PR TITLE
fix routing policy

### DIFF
--- a/lotus-soup/testkit/net.go
+++ b/lotus-soup/testkit/net.go
@@ -80,6 +80,7 @@ func ApplyNetworkParameters(t *TestEnvironment) {
 		Default:        ls,
 		CallbackState:  sync.State(fmt.Sprintf("latency-configured-%s", t.TestGroupID)),
 		CallbackTarget: t.TestGroupInstanceCount,
+		RoutingPolicy:  network.AllowAll,
 	})
 
 	t.DumpJSON("network-link-shape.json", ls)


### PR DESCRIPTION
Due to this, the baseline test is failing on all adapters (since we don't have external connectivity and cant reach public Drand network).

I guess the `testground/sdk-go` package got updated along the way, without this being added.