### PR TITLE
trigger more test plans on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ workflows:
   main:
     jobs:
       - soup-build-linux
-      - trigger-baseline-testplan
+      - trigger-testplans
   nightly:
     triggers:
       - schedule:
@@ -38,7 +38,7 @@ workflows:
               only:
                 - master
     jobs:
-      - trigger-baseline-testplan
+      - trigger-testplans
 
 jobs:
   soup-build-linux:
@@ -48,7 +48,7 @@ jobs:
       - run:
           name: "build lotus-soup"
           command: pushd lotus-soup && go build -tags=testground .
-  trigger-baseline-testplan:
+  trigger-testplans:
     executor: golang
     steps:
       - setup
@@ -59,5 +59,14 @@ jobs:
           name: "prepare .env.toml"
           command: pushd lotus-soup && mkdir -p $HOME/testground && cp env-ci.toml $HOME/testground/.env.toml && echo 'endpoint="'$endpoint'"' >> $HOME/testground/.env.toml && echo 'token="'$token'"' >> $HOME/testground/.env.toml
       - run:
+          name: "prepare testground home dir"
+          command: mkdir -p $HOME/testground/plans && mv lotus-soup $HOME/testground/plans/
+      - run:
           name: "trigger baseline test plan on testground ci"
-          command: mkdir -p $HOME/testground/plans && mv lotus-soup $HOME/testground/plans/ && ~/testground-cli run composition -f $HOME/testground/plans/lotus-soup/_compositions/baseline-k8s-3-1.toml
+          command: ~/testground-cli run composition -f $HOME/testground/plans/lotus-soup/_compositions/baseline-k8s-3-1.toml
+      - run:
+          name: "trigger payment channel stress test plan on testground ci"
+          command: ~/testground-cli run composition -f $HOME/testground/plans/lotus-soup/_compositions/paych-stress-k8s.toml
+      - run:
+          name: "trigger deals stress concurrent test plan on testground ci"
+          command: ~/testground-cli run composition -f $HOME/testground/plans/lotus-soup/_compositions/deals-stress-concurrent-natural-k8s.toml

--- a/lotus-soup/_compositions/paych-stress-k8s.toml
+++ b/lotus-soup/_compositions/paych-stress-k8s.toml
@@ -1,0 +1,56 @@
+[metadata]
+  name = "lotus-soup"
+  author = "raulk"
+
+[global]
+  plan = "lotus-soup"
+  case = "paych-stress"
+  total_instances = 5   # 2 clients + 2 miners + 1 bootstrapper
+  builder = "docker:go"
+  runner = "cluster:k8s"
+
+[global.build]
+  selectors = ["testground"]
+
+[global.run_config]
+  exposed_ports = { pprof = "6060", node_rpc = "1234", miner_rpc = "2345" }
+
+[global.build_config]
+  push_registry=true
+  go_proxy_mode="remote"
+  go_proxy_url="http://localhost:8081"
+  registry_type="aws"
+
+[global.run.test_params]
+  clients = "2"
+  miners = "2"
+  genesis_timestamp_offset = "0"
+  balance = "100"    ## be careful, this is in FIL.
+  sectors = "10"
+  random_beacon_type = "mock"
+  mining_mode = "natural"
+  # number of lanes to send vouchers on
+  lane_count = "8"
+  # number of vouchers on each lane
+  vouchers_per_lane = "3"
+  # amount to increase voucher by each time (per lane)
+  increments = "3" ##  in FIL
+
+[[groups]]
+  id = "bootstrapper"
+  instances = { count = 1 }
+  [groups.run.test_params]
+    role = "bootstrapper"
+
+[[groups]]
+  id = "miners"
+  instances = { count = 2 }
+  [groups.run.test_params]
+    role = "miner"
+
+[[groups]]
+  id = "clients"
+  # the first client will be on the receiving end; all others will be on the sending end.
+  instances = { count = 2 }
+  [groups.run.test_params]
+    role = "client"


### PR DESCRIPTION
This PR is just triggering two more test plans alongside the deals e2e test plan. The idea is to visualise very soon what / where is failing on the CI dashboard, and maybe patch them up soon after that.