### PR TITLE
fix payment channel stress tests

### DIFF
--- a/lotus-soup/go.sum
+++ b/lotus-soup/go.sum
@@ -757,11 +757,9 @@ github.com/kpacha/opencensus-influxdb v0.0.0-20181102202715-663e2683a27c h1:3pM6
 github.com/kpacha/opencensus-influxdb v0.0.0-20181102202715-663e2683a27c/go.mod h1:ESXZSm2iaF+1P5o6VFEWpeARTQpcil4e1DwumnTopdg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -1901,7 +1899,6 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/lotus-soup/paych/stress.go
+++ b/lotus-soup/paych/stress.go
@@ -181,7 +181,7 @@ func runSender(ctx context.Context, t *testkit.TestEnvironment, clients []*testk
 			}
 			t.RecordMessage("payment voucher created; lane=%d, nonce=%d, amount=%d", voucher.Voucher.Lane, voucher.Voucher.Nonce, voucher.Voucher.Amount)
 
-			_, err = t.SyncClient.Publish(ctx, VoucherTopic, voucher)
+			_, err = t.SyncClient.Publish(ctx, VoucherTopic, voucher.Voucher)
 			if err != nil {
 				return fmt.Errorf("failed to publish voucher: %w", err)
 			}


### PR DESCRIPTION
This PR is fixing the payment channel stress tests. There are two problems with them at the moment:
1. Incorrect value sent when publishing to a subscription in the test plan.
2. Some weird ID mismatch caused either by Lotus or specs-actors v0.9.12 or something else, described below:

---

```
Abortf: voucher payment channel address t01002 does not match receiver t2bev75hv5nxtp22pmfs3bquqphjhlqf3z2hwsqlq
```

```
...
{"ts":1601995860076919846,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"payment voucher created; lane=4, nonce=3, amount=9000000000000000000"}}}
{"ts":1601995860077627260,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"remaining balance: 9000000000000000000"}}}
{"ts":1601995860079879518,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"payment voucher created; lane=5, nonce=3, amount=9000000000000000000"}}}
{"ts":1601995860080606931,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"remaining balance: 6000000000000000000"}}}
{"ts":1601995860082887728,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"payment voucher created; lane=6, nonce=3, amount=9000000000000000000"}}}
{"ts":1601995860083579357,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"remaining balance: 3000000000000000000"}}}
{"ts":1601995860085762595,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"payment voucher created; lane=7, nonce=3, amount=9000000000000000000"}}}
{"ts":1601995860086466361,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"remaining balance: 0"}}}
{"ts":1601995860086478950,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"finished sending all payment vouchers"}}}
```

---

```
...
{"ts":1601995830144740770,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"started node API server at 0.0.0.0:1234"}}}
{"ts":1601995830144843195,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"publish our address to the clients addr topic"}}}
{"ts":1601995830145099040,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"waiting for all nodes to be ready"}}}
{"ts":1601995831146085566,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"got 2 miner addrs"}}}
2020-10-06T14:50:32.020Z        WARN    messagepool     messagepool/messagepool.go:1191 could not recover signature for bls message bafy2bzaceahxsewxlqqx4px2gazscue4o3zqheln6m4ezg3hkadmpzlapuxuy
{"ts":1601995832161727878,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"connected peers: 5"}}}
{"ts":1601995832161769787,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"acting as Receiver"}}}
{"ts":1601995832162826866,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"message_event":{"message":"adding 24 payment vouchers"}}}
2020-10-06T14:51:00.026Z        WARN    vm      vm/runtime.go:283       Abortf: voucher payment channel address t01002 does not match receiver t2bev75hv5nxtp22pmfs3bquqphjhlqf3z2hwsqlq
2020-10-06T14:51:00.026Z        WARN    vm      vm/runtime.go:116       VM.Call failure: voucher payment channel address t01002 does not match receiver t2bev75hv5nxtp22pmfs3bquqphjhlqf3z2hwsqlq (RetCode=16):
    github.com/filecoin-project/specs-actors/v2/actors/builtin/paych.Actor.UpdateChannelState
        /go/pkg/mod/github.com/filecoin-project/specs-actors/v2@v2.0.0-20201002200957-bdd876b3bbe9/actors/builtin/paych/paych_actor.go:188
{"ts":1601995860026923419,"msg":"","group_id":"clients","run_id":"btu87b1961nlg5j09aog","event":{"failure_event":{"group":"clients","error":"failed to check voucher spendable: apply message failed: voucher payment channel address t01002 does not match receiver t2bev75hv5nxtp22pmfs3bquqphjhlqf3z2hwsqlq (RetCode=16)"}}}
```