### PR TITLE
fix deals stress tests

### DIFF
--- a/lotus-soup/_compositions/deals-stress-concurrent-natural-k8s.toml
+++ b/lotus-soup/_compositions/deals-stress-concurrent-natural-k8s.toml
@@ -5,7 +5,7 @@
 [global]
   plan = "lotus-soup"
   case = "deals-stress"
-  total_instances = 9
+  total_instances = 6
   builder = "docker:go"
   runner = "cluster:k8s"
 
@@ -22,17 +22,18 @@
   registry_type="aws"
 
 [global.run.test_params]
-  clients = "6"
+  clients = "3"
   miners = "2"
   genesis_timestamp_offset = "0"
-  balance = "20000000" # These balances will work for maximum 100 nodes, as TotalFilecoin is 2B
-  sectors = "100"
+  balance = "90000000" # These balances will work for maximum 100 nodes, as TotalFilecoin is 2B
+  sectors = "10"
   random_beacon_type = "mock"
+  mining_mode = "natural"
 
 [[groups]]
   id = "bootstrapper"
   [groups.resources]
-    memory = "2048Mi"
+    memory = "512Mi"
     cpu = "100m"
   [groups.instances]
     count = 1
@@ -52,7 +53,6 @@
   [groups.run]
     [groups.run.test_params]
       role = "miner"
-      mining_mode = "natural"
 
 [[groups]]
   id = "clients"
@@ -60,10 +60,10 @@
     memory = "2048Mi"
     cpu = "100m"
   [groups.instances]
-    count = 6
+    count = 3
     percentage = 0.0
   [groups.run]
     [groups.run.test_params]
       role = "client"
-      deals = "5"
+      deals = "3"
       deal_mode = "concurrent"

--- a/lotus-soup/deals_stress.go
+++ b/lotus-soup/deals_stress.go
@@ -39,7 +39,7 @@ func dealsStress(t *testkit.TestEnvironment) error {
 
 	t.RecordMessage("selected %s as the miner", minerAddr.MinerActorAddr)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(12 * time.Second)
 
 	// prepare a number of concurrent data points
 	deals := t.IntParam("deals")

--- a/lotus-soup/testkit/deals.go
+++ b/lotus-soup/testkit/deals.go
@@ -27,7 +27,7 @@ func StartDeal(ctx context.Context, minerActorAddr address.Address, client api.F
 		},
 		Wallet:            addr,
 		Miner:             minerActorAddr,
-		EpochPrice:        types.NewInt(1000000),
+		EpochPrice:        types.NewInt(1000),
 		MinBlocksDuration: 640000,
 		DealStartEpoch:    200,
 		FastRetrieval:     fastRetrieval,

--- a/lotus-soup/testkit/deals.go
+++ b/lotus-soup/testkit/deals.go
@@ -28,7 +28,7 @@ func StartDeal(ctx context.Context, minerActorAddr address.Address, client api.F
 		Wallet:            addr,
 		Miner:             minerActorAddr,
 		EpochPrice:        types.NewInt(1000),
-		MinBlocksDuration: 64000,
+		MinBlocksDuration: 640000,
 		DealStartEpoch:    200,
 		FastRetrieval:     fastRetrieval,
 	})

--- a/lotus-soup/testkit/deals.go
+++ b/lotus-soup/testkit/deals.go
@@ -28,7 +28,7 @@ func StartDeal(ctx context.Context, minerActorAddr address.Address, client api.F
 		Wallet:            addr,
 		Miner:             minerActorAddr,
 		EpochPrice:        types.NewInt(1000),
-		MinBlocksDuration: 640000,
+		MinBlocksDuration: 64000,
 		DealStartEpoch:    200,
 		FastRetrieval:     fastRetrieval,
 	})


### PR DESCRIPTION
Problem:
```
│ tg-lotus-soup-btuf5q1961nvkvepbg80-clients-1 {"ts":1602024283015012616,"msg":"","group_id":"clients","run_id":"btuf5q1961nvkvepbg80","event":{"message_event":{"message":"deal state: StorageDealCheckForAcceptance"}}}                    │
│ tg-lotus-soup-btuf5q1961nvkvepbg80-clients-1 2020-10-06T22:44:43.144Z    ERROR    storagemarket_impl    clientstates/client_states.go:289    deal bafyreiaaighyiszkeovze4dayvsjxqk7ecjpz6jfaaryxj7njxd4ltwt54 failed: deal failed: (State= │
│ 26) error calling node: publishing deal: GasEstimateMessageGas error: estimating gas used: message execution failed: exit 16, reason: Provider collateral out of bounds. (RetCode=16)                                                      │
│ tg-lotus-soup-btuf5q1961nvkvepbg80-clients-1 2020-10-06T22:44:43.166Z    ERROR    storagemarket_impl    clientstates/client_states.go:289    deal bafyreigdjj72upepll76z7j23qb4lhtpps4dvx3vktwcamtaomgtw47ykq failed: deal failed: (State= │
│ 26) error calling node: publishing deal: GasEstimateMessageGas error: estimating gas used: message execution failed: exit 16, reason: Provider collateral out of bounds. (RetCode=16)
```

This PR is amending the parameters used in the `deals-e2e` stress test. It looks like we are not setting up initial balances for clients and miners to support the number of concurrent deals we want to do, most probably due to the `StartDeal` parameters.

I am reducing a bit the concurrency factor and the number of clients creating deals with miners, so that the test passes, and then we can scale it up gradually, while keeping it passing.