### PR TITLE
increase delay before starting of storage deal

### DIFF
--- a/lotus-soup/deals_stress.go
+++ b/lotus-soup/deals_stress.go
@@ -81,11 +81,10 @@ func dealsStress(t *testkit.TestEnvironment) error {
 	}
 
 	// this to avoid failure to get block
-	time.Sleep(2 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	t.RecordMessage("starting storage deals")
 	if concurrentDeals {
-
 		var wg1 sync.WaitGroup
 		for i := 0; i < deals; i++ {
 			wg1.Add(1)
@@ -120,9 +119,7 @@ func dealsStress(t *testkit.TestEnvironment) error {
 		t.RecordMessage("waiting for all retrieval deals to complete")
 		wg2.Wait()
 		t.RecordMessage("all retrieval deals successful")
-
 	} else {
-
 		for i := 0; i < deals; i++ {
 			deal := testkit.StartDeal(ctx, minerAddr.MinerActorAddr, client, cids[i], false)
 			t.RecordMessage("started storage deal %d -> %s", i, deal)


### PR DESCRIPTION
Storage deals have been flaky with the following error message:

```
tg-lotus-soup-bu25rsp961nsf8cpnbg0-clients-2 | {"ts":1602510412168376713,"msg":"","group_id":"clients","run_id":"bu25rsp961nsf8cpnbg0","event":{"message_event":{"message":"started storage deal 1 -> bafyreig5amdmziyl2coxfopu5r3qvvobqfkszsk64kbpwim7eyqx4qkilm"}}}
tg-lotus-soup-bu25rsp961nsf8cpnbg0-clients-2 | {"ts":1602510412168487432,"msg":"","group_id":"clients","run_id":"bu25rsp961nsf8cpnbg0","event":{"message_event":{"message":"started storage deal 2 -> bafyreiho3hpcwp5e7nmvl7qyen2uyvkzcxtcrnqup4fjdekbii5jp5aa6m"}}}
tg-lotus-soup-bu25rsp961nsf8cpnbg0-clients-2 | {"ts":1602510412168597837,"msg":"","group_id":"clients","run_id":"bu25rsp961nsf8cpnbg0","event":{"message_event":{"message":"started storage deal 0 -> bafyreierktbi6nrfaidpjlwect4cvgydqsurjr7apyryzvyewtavmiteoe"}}}
tg-lotus-soup-bu25rsp961nsf8cpnbg0-clients-2 | 2020-10-12T13:46:52.184Z	[31mERROR[0m	storagemarket_impl	clientstates/client_states.go:289	deal bafyreiho3hpcwp5e7nmvl7qyen2uyvkzcxtcrnqup4fjdekbii5jp5aa6m failed: unexpected deal status while waiting for data request: 11 (StorageDealFailing). Provider message: deal rejected: clientMarketBalance.Available too small
```

I am not exactly sure, why increasing the sleep prior to starting a deal helps, but it seems to help. The comment `// this to avoid failure to get block` makes me think that we need to wait for a few epochs before starting a deal.