### PR TITLE
scale measurements; fix tags

### DIFF
--- a/graphsync/go.mod
+++ b/graphsync/go.mod
@@ -3,6 +3,7 @@ module github.com/libp2p/test-plans/ping
 go 1.14
 
 require (
+	github.com/dustin/go-humanize v1.0.0
 	github.com/hannahhoward/all-selector v0.1.0
 	github.com/ipfs/go-blockservice v0.1.3
 	github.com/ipfs/go-cid v0.0.6
@@ -23,7 +24,7 @@ require (
 	github.com/libp2p/go-libp2p-secio v0.2.2
 	github.com/libp2p/go-libp2p-tls v0.1.3
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/testground/sdk-go v0.2.6-0.20201016180515-1e40e1b0ec3a
+	github.com/testground/sdk-go v0.2.7-0.20201112151952-8ee00c80c3ec
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
 	google.golang.org/protobuf v1.25.0 // indirect

--- a/graphsync/go.sum
+++ b/graphsync/go.sum
@@ -725,6 +725,8 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/testground/sdk-go v0.2.6-0.20201016180515-1e40e1b0ec3a h1:iQDLQpTGtdfatdQtGqQBuoXFrl2AQ0n3Q8mNKkqbmnw=
 github.com/testground/sdk-go v0.2.6-0.20201016180515-1e40e1b0ec3a/go.mod h1:Q4dnWsUBH+dZ1u7aEGDBHWGUaLfhitjUq3UJQqxeTmk=
+github.com/testground/sdk-go v0.2.7-0.20201112151952-8ee00c80c3ec h1:ZigYjS91IfPRStWGEZuI8/QDes9vPKpwnmLmc3AVQns=
+github.com/testground/sdk-go v0.2.7-0.20201112151952-8ee00c80c3ec/go.mod h1:Q4dnWsUBH+dZ1u7aEGDBHWGUaLfhitjUq3UJQqxeTmk=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=

--- a/graphsync/main.go
+++ b/graphsync/main.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	goruntime "runtime"
+	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	allselector "github.com/hannahhoward/all-selector"
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
@@ -211,7 +213,10 @@ func runRequestor(ctx context.Context, runenv *runtime.RunEnv, initCtx *run.Init
 
 				runenv.RecordMessage("\t<<< request complete with no errors")
 				runenv.RecordMessage("***** ROUND %d observed duration (lat=%s,bw=%d): %s", round, np.latency, np.bandwidth, dur)
-				runenv.R().RecordPoint(fmt.Sprintf("duration,lat=%s,bw=%d,concurrency=%d,size=%d", np.latency, np.bandwidth, concurrency, size), float64(dur))
+
+				measurement := fmt.Sprintf("duration.sec,lat=%s,bw=%s,concurrency=%d,size=%s", np.latency, humanize.IBytes(np.bandwidth), concurrency, humanize.Bytes(size))
+				measurement = strings.Replace(measurement, " ", "", -1)
+				runenv.R().RecordPoint(measurement, float64(dur)/float64(time.Second))
 
 				// verify that we have the CID now.
 				if node, err := dagsrv.Get(grpctx, c); err != nil {


### PR DESCRIPTION
This PR is fixing the sending of metrics from `graphsync` to:
1. Scale metrics to seconds range, since the results we get are between 1 and 80sec.
2. Add unit (`sec`) to the measurement so that it is clear that we are emitting seconds.
3. Add humanized tags for `bw` and `latency`.
4. Using the `go-sdk` from `master`, since it contains the update storing of metrics (i.e. including the testplan and testcase in the measurement name).